### PR TITLE
test: add Phase 3 test coverage (offline sync, navigation context, lo…

### DIFF
--- a/src/components/LoginScreen.test.tsx
+++ b/src/components/LoginScreen.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import LoginScreen from './LoginScreen'
+
+// Shared auth mock — hoisted so the mock factory can reference it before the
+// const declarations are reached by the JS engine.
+const mockAuth = vi.hoisted(() => ({
+  signInWithPassword: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+  signUp: vi.fn().mockResolvedValue({ data: { session: null, user: null }, error: null }),
+  signInWithOAuth: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  getUser: vi.fn().mockResolvedValue({ data: { user: { email: 'test@example.com' } }, error: null }),
+}))
+
+vi.mock('../utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({ auth: mockAuth })),
+}))
+
+vi.mock('../services/organization.service', () => ({
+  convertPendingToActive: vi.fn().mockResolvedValue(undefined),
+}))
+
+const mockOnLogin = vi.fn()
+
+describe('LoginScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Restore default happy-path behaviour
+    mockAuth.signInWithPassword.mockResolvedValue({ data: { session: null }, error: null })
+    mockAuth.signUp.mockResolvedValue({ data: { session: null, user: null }, error: null })
+    mockAuth.signInWithOAuth.mockResolvedValue({ data: {}, error: null })
+    mockAuth.getUser.mockResolvedValue({ data: { user: { email: 'test@example.com' } }, error: null })
+  })
+
+  it('renders without throwing errors', () => {
+    expect(() => render(<LoginScreen onLogin={mockOnLogin} />)).not.toThrow()
+  })
+
+  it('renders the sign-in email and password inputs', () => {
+    render(<LoginScreen onLogin={mockOnLogin} />)
+    expect(document.getElementById('signin-email')).not.toBeNull()
+    expect(document.getElementById('signin-password')).not.toBeNull()
+  })
+
+  it('renders the sign-in submit button', () => {
+    render(<LoginScreen onLogin={mockOnLogin} />)
+    expect(screen.getByRole('button', { name: /sign in with email/i })).toBeTruthy()
+  })
+
+  it('disables the submit button while a sign-in is in flight', async () => {
+    // Never resolves — simulates a slow network
+    mockAuth.signInWithPassword.mockReturnValue(new Promise(() => {}))
+
+    render(<LoginScreen onLogin={mockOnLogin} />)
+
+    const emailInput = document.getElementById('signin-email') as HTMLInputElement
+    const passwordInput = document.getElementById('signin-password') as HTMLInputElement
+    fireEvent.change(emailInput, { target: { value: 'user@example.com' } })
+    fireEvent.change(passwordInput, { target: { value: 'password123' } })
+
+    const submitButton = screen.getByRole('button', { name: /sign in with email/i })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled()
+    })
+  })
+
+  it('displays an error alert when sign-in returns an auth error', async () => {
+    mockAuth.signInWithPassword.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'Invalid login credentials' },
+    })
+
+    render(<LoginScreen onLogin={mockOnLogin} />)
+
+    const emailInput = document.getElementById('signin-email') as HTMLInputElement
+    const passwordInput = document.getElementById('signin-password') as HTMLInputElement
+    fireEvent.change(emailInput, { target: { value: 'wrong@example.com' } })
+    fireEvent.change(passwordInput, { target: { value: 'wrongpass' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in with email/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/invalid email or password/i)
+      ).toBeTruthy()
+    })
+  })
+
+  it('calls signInWithPassword with the entered email and password', async () => {
+    // Return an error so we don't need to stub the full post-login flow
+    mockAuth.signInWithPassword.mockResolvedValue({
+      data: { session: null },
+      error: { message: 'test error' },
+    })
+
+    render(<LoginScreen onLogin={mockOnLogin} />)
+
+    const emailInput = document.getElementById('signin-email') as HTMLInputElement
+    const passwordInput = document.getElementById('signin-password') as HTMLInputElement
+    fireEvent.change(emailInput, { target: { value: 'alice@example.com' } })
+    fireEvent.change(passwordInput, { target: { value: 'secret123' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in with email/i }))
+
+    await waitFor(() => {
+      expect(mockAuth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'alice@example.com',
+        password: 'secret123',
+      })
+    })
+  })
+
+  it('renders the Google sign-in button', () => {
+    render(<LoginScreen onLogin={mockOnLogin} />)
+    expect(screen.getByRole('button', { name: /continue with google/i })).toBeTruthy()
+  })
+
+  it('renders both Sign In and Sign Up tab triggers', () => {
+    render(<LoginScreen onLogin={mockOnLogin} />)
+    expect(screen.getByRole('tab', { name: /sign in/i })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: /sign up/i })).toBeTruthy()
+  })
+})

--- a/src/contexts/NavigationContext.test.tsx
+++ b/src/contexts/NavigationContext.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, renderHook } from '@testing-library/react'
+import React from 'react'
+import { NavigationProvider, useNavigation } from './NavigationContext'
+
+const defaultHandlers = {
+  onNavigateToDashboard: vi.fn(),
+  onNavigateToGigs: vi.fn(),
+  onNavigateToTeam: vi.fn(),
+  onNavigateToAssets: vi.fn(),
+}
+
+describe('NavigationProvider', () => {
+  it('renders children without crashing', () => {
+    expect(() =>
+      render(
+        <NavigationProvider {...defaultHandlers}>
+          <div>child</div>
+        </NavigationProvider>
+      )
+    ).not.toThrow()
+  })
+
+  it('renders child content', () => {
+    render(
+      <NavigationProvider {...defaultHandlers}>
+        <span>hello world</span>
+      </NavigationProvider>
+    )
+    expect(screen.getByText('hello world')).toBeTruthy()
+  })
+})
+
+describe('useNavigation', () => {
+  it('returns null outside of NavigationProvider', () => {
+    const { result } = renderHook(() => useNavigation())
+    expect(result.current).toBeNull()
+  })
+
+  it('returns context value with required callbacks inside provider', () => {
+    const handlers = {
+      onNavigateToDashboard: vi.fn(),
+      onNavigateToGigs: vi.fn(),
+      onNavigateToTeam: vi.fn(),
+      onNavigateToAssets: vi.fn(),
+    }
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NavigationProvider {...handlers}>{children}</NavigationProvider>
+    )
+
+    const { result } = renderHook(() => useNavigation(), { wrapper })
+
+    expect(result.current).not.toBeNull()
+    expect(result.current?.onNavigateToDashboard).toBe(handlers.onNavigateToDashboard)
+    expect(result.current?.onNavigateToGigs).toBe(handlers.onNavigateToGigs)
+    expect(result.current?.onNavigateToTeam).toBe(handlers.onNavigateToTeam)
+    expect(result.current?.onNavigateToAssets).toBe(handlers.onNavigateToAssets)
+  })
+
+  it('propagates optional callbacks when supplied', () => {
+    const handlers = {
+      ...defaultHandlers,
+      onEditProfile: vi.fn(),
+      onNavigateToSettings: vi.fn(),
+    }
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NavigationProvider {...handlers}>{children}</NavigationProvider>
+    )
+
+    const { result } = renderHook(() => useNavigation(), { wrapper })
+
+    expect(result.current?.onEditProfile).toBe(handlers.onEditProfile)
+    expect(result.current?.onNavigateToSettings).toBe(handlers.onNavigateToSettings)
+  })
+
+  it('optional callbacks are undefined when not supplied', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NavigationProvider {...defaultHandlers}>{children}</NavigationProvider>
+    )
+
+    const { result } = renderHook(() => useNavigation(), { wrapper })
+
+    expect(result.current?.onEditProfile).toBeUndefined()
+    expect(result.current?.onNavigateToSettings).toBeUndefined()
+  })
+
+  it('calling a navigation callback invokes the provided handler', () => {
+    const onNavigateToDashboard = vi.fn()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NavigationProvider
+        {...defaultHandlers}
+        onNavigateToDashboard={onNavigateToDashboard}
+      >
+        {children}
+      </NavigationProvider>
+    )
+
+    const { result } = renderHook(() => useNavigation(), { wrapper })
+    result.current?.onNavigateToDashboard()
+
+    expect(onNavigateToDashboard).toHaveBeenCalledOnce()
+  })
+})

--- a/src/services/mobile/offlineSync.service.test.ts
+++ b/src/services/mobile/offlineSync.service.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// vi.hoisted ensures these exist before vi.mock factory runs,
+// which is important because offlineSync.service calls createClient()
+// at module scope (not inside a function).
+const mockFrom = vi.hoisted(() => vi.fn())
+const mockRpc = vi.hoisted(() => vi.fn())
+
+vi.mock('../../utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    from: mockFrom,
+    rpc: mockRpc,
+  })),
+}))
+
+vi.mock('../../utils/idb/store', () => ({
+  idbStore: {
+    getOutbox: vi.fn().mockResolvedValue([]),
+    addToOutbox: vi.fn().mockResolvedValue(1),
+    removeFromOutbox: vi.fn().mockResolvedValue(undefined),
+    updateOutboxItem: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { offlineSyncService } from './offlineSync.service'
+import type { OutboxItem } from '../../utils/idb/store'
+
+// Build a chainable query builder that resolves to `result` when awaited.
+// Intermediate methods (select, insert, delete, etc.) return `this`.
+// Terminal methods (maybeSingle) return a Promise.
+// The chain itself is thenable so `await chain` works directly.
+function makeChain(result: { data: any; error: any }) {
+  const chain: any = {}
+  const chainMethods = ['select', 'insert', 'update', 'delete', 'eq', 'neq', 'is', 'order', 'limit']
+  chainMethods.forEach(m => {
+    chain[m] = vi.fn().mockReturnValue(chain)
+  })
+  chain.maybeSingle = vi.fn().mockResolvedValue(result)
+  chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject)
+  return chain
+}
+
+function outboxItem(type: OutboxItem['type'], payload: any): OutboxItem {
+  return { type, payload, timestamp: Date.now(), attempts: 0 }
+}
+
+describe('offlineSyncService — INVENTORY_SCAN handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('inserts all required fields to inventory_tracking', async () => {
+    const chain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_SCAN', {
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      asset_id: 'asset-1',
+      status: 'In Warehouse',
+      scanned_at: '2026-03-15T12:00:00Z',
+      scanned_by: 'user-1',
+      notes: 'test note',
+    }))
+
+    expect(mockFrom).toHaveBeenCalledWith('inventory_tracking')
+    expect(chain.insert).toHaveBeenCalledWith({
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      asset_id: 'asset-1',
+      status: 'In Warehouse',
+      scanned_at: '2026-03-15T12:00:00Z',
+      scanned_by: 'user-1',
+      notes: 'test note',
+    })
+  })
+
+  it('coerces absent asset_id to null', async () => {
+    const chain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_SCAN', {
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      // no asset_id
+      status: 'In Warehouse',
+      scanned_at: '2026-03-15T12:00:00Z',
+      scanned_by: 'user-1',
+    }))
+
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ asset_id: null }))
+  })
+
+  it('coerces absent notes to null', async () => {
+    const chain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_SCAN', {
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      asset_id: 'asset-1',
+      status: 'In Warehouse',
+      scanned_at: '2026-03-15T12:00:00Z',
+      scanned_by: 'user-1',
+      // no notes
+    }))
+
+    expect(chain.insert).toHaveBeenCalledWith(expect.objectContaining({ notes: null }))
+  })
+
+  it('throws when Supabase insert returns an error', async () => {
+    const chain = makeChain({ data: null, error: { message: 'insert failed' } })
+    mockFrom.mockReturnValue(chain)
+
+    await expect(
+      offlineSyncService.syncItem(outboxItem('INVENTORY_SCAN', {
+        organization_id: 'org-1',
+        gig_id: 'gig-1',
+        kit_id: 'kit-1',
+        asset_id: null,
+        status: 'In Warehouse',
+        scanned_at: '2026-03-15T12:00:00Z',
+        scanned_by: 'user-1',
+        notes: null,
+      }))
+    ).rejects.toEqual({ message: 'insert failed' })
+  })
+})
+
+describe('offlineSyncService — INVENTORY_CLEAR handler (by record_id)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deletes the specific row by record_id without querying for latest', async () => {
+    const chain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+      record_id: 'rec-42',
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+    }))
+
+    // Exactly one from() call (just the delete; no query-latest round-trip)
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+    expect(mockFrom).toHaveBeenCalledWith('inventory_tracking')
+    expect(chain.delete).toHaveBeenCalled()
+    expect(chain.eq).toHaveBeenCalledWith('id', 'rec-42')
+  })
+
+  it('throws when Supabase delete returns an error', async () => {
+    const chain = makeChain({ data: null, error: { message: 'delete failed' } })
+    mockFrom.mockReturnValue(chain)
+
+    await expect(
+      offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+        record_id: 'rec-42',
+        gig_id: 'gig-1',
+        kit_id: 'kit-1',
+      }))
+    ).rejects.toEqual({ message: 'delete failed' })
+  })
+})
+
+describe('offlineSyncService — INVENTORY_CLEAR handler (bulk, no record_id)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('queries for latest tracking row then deletes it by id', async () => {
+    const queryChain = makeChain({ data: { id: 'rec-latest' }, error: null })
+    const deleteChain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(queryChain).mockReturnValueOnce(deleteChain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+    }))
+
+    expect(mockFrom).toHaveBeenCalledTimes(2)
+    expect(deleteChain.delete).toHaveBeenCalled()
+    expect(deleteChain.eq).toHaveBeenCalledWith('id', 'rec-latest')
+  })
+
+  it('applies asset_id filter when asset_id is present in payload', async () => {
+    const queryChain = makeChain({ data: { id: 'rec-asset' }, error: null })
+    const deleteChain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(queryChain).mockReturnValueOnce(deleteChain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      asset_id: 'asset-1',
+    }))
+
+    expect(queryChain.eq).toHaveBeenCalledWith('asset_id', 'asset-1')
+  })
+
+  it('applies IS NULL filter when asset_id is absent from payload', async () => {
+    const queryChain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(queryChain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+      // no asset_id
+    }))
+
+    expect(queryChain.is).toHaveBeenCalledWith('asset_id', null)
+  })
+
+  it('returns early without deleting when no latest record exists', async () => {
+    const queryChain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(queryChain)
+
+    await offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+      gig_id: 'gig-1',
+      kit_id: 'kit-1',
+    }))
+
+    // Only the query call; no delete call
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws when the query for latest returns an error', async () => {
+    const queryChain = makeChain({ data: null, error: { message: 'query failed' } })
+    mockFrom.mockReturnValue(queryChain)
+
+    await expect(
+      offlineSyncService.syncItem(outboxItem('INVENTORY_CLEAR', {
+        gig_id: 'gig-1',
+        kit_id: 'kit-1',
+      }))
+    ).rejects.toEqual({ message: 'query failed' })
+  })
+})


### PR DESCRIPTION
…gin screen)

- offlineSync.service.test.ts: 11 tests covering INVENTORY_SCAN field coercion (asset_id/notes null), INVENTORY_CLEAR by record_id vs bulk (latest-row query path), and error propagation from Supabase
- NavigationContext.test.tsx: 7 tests covering provider renders, children propagation, useNavigation returning null outside provider, required and optional callback pass-through, and direct invocation
- LoginScreen.test.tsx: 8 tests covering render, input presence, submit button disable-while-loading, error display on auth failure, and signInWithPassword called with correct credentials

Uses vi.hoisted to share mutable mock references with vi.mock factories, enabling per-test control of Supabase chain results even for services that call createClient() at module scope.

https://claude.ai/code/session_01232EcSTQtXWEWTyRNS7grQ