### PR TITLE
Fix expense→gig linking: $0 ledger amount, slow gig picker, button overlap

### DIFF
--- a/docs/development/expense-gig-linking-and-receipts-manual-test-checklist.md
+++ b/docs/development/expense-gig-linking-and-receipts-manual-test-checklist.md
@@ -129,6 +129,34 @@ reading the right number.
       Gig A show **$400**, and Gig A + Gig B costs never summed to more than **$200**.
 - [x] Leave `Van rental` assigned to **Gig A** with its ledger entry — Part 6 uses it.
 
+### 1.5 — 🐛 Scanned / cost-only expense records its real amount, not $0
+
+*Regression: `Van rental` above is entered with a **price**, so `line_amount` is set. Scanned
+invoices and CSV "cost" rows populate only `line_cost` / `item_cost` — `line_amount` and
+`item_price` are null. The ledger amount used to read `line_amount` first and so recorded **$0**
+for every scanned expense.*
+
+- [ ] **Upload Invoice** (or Add New) a receipt whose expense line has a **Cost** but no unit
+      **Price** — e.g. a one-line `Van Rental` at **$66.73**. In the expanded line detail the
+      **Line Cost** shows `$66.73` while **Item Price** / **Line Amt** show `-`.
+- [ ] Expand the line → **Assign Gig** → pick a gig. The **"Create gig expense record?"** prompt
+      names **$66.73** (not **$0.00**). Click **Create record**.
+- [ ] That gig's Financials **Costs** rises by **$66.73**, and the new `Van Rental` expense row
+      reads **$66.73**.
+- [ ] Same check via the persistent path: **Skip** the prompt, then click **Add to gig ledger**
+      on the line — the created entry is **$66.73**, not $0.
+
+### 1.6 — Assign Gig picker is scoped to gigs near the expense date
+
+*The picker now loads only gigs starting within ~3 weeks of the line's purchase date (plus the
+currently-linked gig), instead of the org's whole gig history — this is what fixed the ~45s
+dropdown stall.*
+
+- [ ] Expand a line and open **Assign Gig**. The list contains gigs near the receipt date; a
+      footer reads **"Showing gigs near <date>"**. A gig months away is **not** listed.
+- [ ] Assign the line to a gig, reload Purchases, expand it again: the linked gig still shows its
+      full label in the picker even if it's outside the date window.
+
 ---
 
 ## Part 2 — Attach a receipt to a gig expense, on web (✨ NEW FEATURE)

--- a/src/components/financials/purchases/GigCombobox.tsx
+++ b/src/components/financials/purchases/GigCombobox.tsx
@@ -14,7 +14,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '../../ui/popover';
-import { getGigsForOrganization } from '../../../services/gig.service';
+import { getGigOptionsForOrganization } from '../../../services/gig.service';
 
 interface GigOption {
   id: string;
@@ -32,18 +32,26 @@ interface GigComboboxProps {
   placeholder?: string;
   /** Hide the inline "clear" (X) button — for callers that don't support unassigning here. */
   hideClear?: boolean;
+  /**
+   * Reference date (e.g. the expense's purchase date). When set, the list is
+   * scoped to gigs starting within a few weeks of it instead of loading the
+   * org's entire gig history — the currently linked gig is always kept.
+   */
+  aroundDate?: string | null;
 }
 
-export default function GigCombobox({ organizationId, value, onChange, disabled, placeholder = 'Select gig...', hideClear }: GigComboboxProps) {
+export default function GigCombobox({ organizationId, value, onChange, disabled, placeholder = 'Select gig...', hideClear, aroundDate }: GigComboboxProps) {
   const [open, setOpen] = useState(false);
   const [gigs, setGigs] = useState<GigOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (!organizationId) return;
+    let cancelled = false;
     setIsLoading(true);
-    getGigsForOrganization(organizationId)
-      .then((data: any[]) => {
+    getGigOptionsForOrganization(organizationId, { aroundDate, ensureGigId: value })
+      .then((data) => {
+        if (cancelled) return;
         setGigs(data.map(g => ({
           id: g.id,
           title: g.title,
@@ -53,8 +61,9 @@ export default function GigCombobox({ organizationId, value, onChange, disabled,
         })));
       })
       .catch(() => {})
-      .finally(() => setIsLoading(false));
-  }, [organizationId]);
+      .finally(() => { if (!cancelled) setIsLoading(false); });
+    return () => { cancelled = true; };
+  }, [organizationId, aroundDate, value]);
 
   const selectedGig = gigs.find(g => g.id === value);
 
@@ -67,7 +76,7 @@ export default function GigCombobox({ organizationId, value, onChange, disabled,
   };
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-1 min-w-0">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -75,7 +84,7 @@ export default function GigCombobox({ organizationId, value, onChange, disabled,
             role="combobox"
             aria-expanded={open}
             disabled={disabled}
-            className="h-8 text-xs justify-between flex-1 font-normal"
+            className="h-8 text-xs justify-between flex-1 min-w-0 shrink font-normal"
           >
             <span className="truncate">
               {selectedGig ? formatLabel(selectedGig) : placeholder}
@@ -104,6 +113,11 @@ export default function GigCombobox({ organizationId, value, onChange, disabled,
                   </CommandItem>
                 ))}
               </CommandGroup>
+              {aroundDate && !isLoading && (
+                <p className="px-2 py-1.5 text-[10px] text-gray-400 border-t">
+                  Showing gigs near {new Date(aroundDate).toLocaleDateString()}
+                </p>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>
@@ -112,7 +126,7 @@ export default function GigCombobox({ organizationId, value, onChange, disabled,
         <Button
           variant="ghost"
           size="sm"
-          className="h-8 w-8 p-0 text-gray-400 hover:text-red-500"
+          className="h-8 w-8 p-0 shrink-0 text-gray-400 hover:text-red-500"
           onClick={() => onChange(null)}
           disabled={disabled}
           title="Clear gig"

--- a/src/components/financials/purchases/PurchasesTab.tsx
+++ b/src/components/financials/purchases/PurchasesTab.tsx
@@ -65,7 +65,7 @@ import {
   assignGigToPurchaseChildren,
 } from '../../../services/purchase.service';
 import { getEntityAttachments, uploadAttachment, linkAttachmentToEntity } from '../../../services/attachment.service';
-import { getGigsForOrganization, getGigFinancialsByPurchaseId, getPurchaseIdsWithLedgerEntry } from '../../../services/gig.service';
+import { getGigOptionsForOrganization, getGigFinancialsByPurchaseId, getPurchaseIdsWithLedgerEntry } from '../../../services/gig.service';
 import { toast } from 'sonner';
 import { isSyntheticHeader } from './reconciliation';
 import PurchaseDetailPanel, { PanelState } from './PurchaseDetailPanel';
@@ -154,8 +154,8 @@ export default function PurchasesTab({
   }, [organization.id]);
 
   useEffect(() => {
-    getGigsForOrganization(organization.id)
-      .then((gigs: any[]) => {
+    getGigOptionsForOrganization(organization.id)
+      .then((gigs) => {
         const map = new Map<string, string>();
         gigs.forEach(g => map.set(g.id, g.title));
         setGigNames(map);
@@ -819,6 +819,7 @@ export default function PurchasesTab({
                         <GigCombobox
                           organizationId={organization.id}
                           value={group.header.gig_id || null}
+                          aroundDate={group.header.purchase_date}
                           placeholder="Assign receipt to gig…"
                           hideClear
                           onChange={(gigId, gigTitle) => { if (gigId) handleAssignHeaderGig(group.header, gigId, gigTitle); }}
@@ -1002,6 +1003,7 @@ export default function PurchasesTab({
                                   <GigCombobox
                                     organizationId={organization.id}
                                     value={item.gig_id || null}
+                                    aroundDate={item.purchase_date}
                                     onChange={(gigId, gigTitle) => handleAssignGig(item, gigId, gigTitle)}
                                     disabled={assigningGigItemId === item.id}
                                   />

--- a/src/services/gig.service.test.ts
+++ b/src/services/gig.service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getGig,
   getGigsForOrganization,
+  getGigOptionsForOrganization,
   deleteGig,
   getGigFinancials,
   getGigFinancialsByPurchaseId,
@@ -171,6 +172,65 @@ describe('gig.service', () => {
       mockSupabase.from.mockReturnValue(makeChain({ data: null, error: dbError }));
 
       await expect(getGigsForOrganization('org-1')).rejects.toThrow('connection refused');
+    });
+  });
+
+  // ─── getGigOptionsForOrganization ─────────────────────────────────────────
+
+  describe('getGigOptionsForOrganization', () => {
+    const setup = (gigRows: any[]) => {
+      const participantChain = makeChain({ data: [{ gig_id: 'gig-1' }], error: null });
+      const gigChain = makeChain({ data: gigRows, error: null });
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'gig_participants') return participantChain;
+        if (table === 'gigs') return gigChain;
+        return makeChain({ data: [], error: null });
+      });
+      return { participantChain, gigChain };
+    };
+
+    it('returns [] when the org participates in no gigs', async () => {
+      mockSupabase.from.mockReturnValue(makeChain({ data: [], error: null }));
+      expect(await getGigOptionsForOrganization('org-1')).toEqual([]);
+    });
+
+    it('maps venue/act names and does not filter by date when no aroundDate is given', async () => {
+      const { gigChain } = setup([
+        {
+          id: 'gig-1',
+          title: 'Festival',
+          start: '2026-06-01T18:00:00Z',
+          participants: [
+            { role: 'Venue', organization: { name: 'The Venue' } },
+            { role: 'Act', organization: { name: 'The Band' } },
+          ],
+        },
+      ]);
+
+      const result = await getGigOptionsForOrganization('org-1');
+
+      expect(gigChain.or).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'gig-1', title: 'Festival', start: '2026-06-01T18:00:00Z', venue: { name: 'The Venue' }, act: { name: 'The Band' } },
+      ]);
+    });
+
+    it('scopes to a ±window around aroundDate and always keeps the linked gig', async () => {
+      const { gigChain } = setup([]);
+
+      await getGigOptionsForOrganization('org-1', { aroundDate: '2025-12-19', windowDays: 21, ensureGigId: 'gig-far' });
+
+      expect(gigChain.or).toHaveBeenCalledTimes(1);
+      const orArg = (gigChain.or as any).mock.calls[0][0] as string;
+      expect(orArg).toContain('start.gte.2025-11-28T00:00:00.000Z');
+      expect(orArg).toContain('start.lte.2026-01-09T23:59:59.999Z');
+      expect(orArg).toContain('id.eq.gig-far');
+    });
+
+    it('ignores an unparseable aroundDate rather than filtering everything out', async () => {
+      const { gigChain } = setup([]);
+      await getGigOptionsForOrganization('org-1', { aroundDate: 'not-a-date' });
+      expect(gigChain.or).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/gig.service.ts
+++ b/src/services/gig.service.ts
@@ -200,6 +200,79 @@ export async function getGigsForOrganization(organizationId: string) {
   }
 }
 
+export interface GigOption {
+  id: string;
+  title: string;
+  start: string;
+  venue?: { name?: string } | null;
+  act?: { name?: string } | null;
+}
+
+/** Default half-width of the date window used to scope gig pickers, in days. */
+export const GIG_PICKER_WINDOW_DAYS = 21;
+
+/**
+ * Lightweight gig list for pickers (comboboxes, summary name maps).
+ *
+ * Two things make this cheaper than `getGigsForOrganization`:
+ *  - it selects only the columns a picker renders (`id`, `title`, `start`) plus
+ *    the venue/act name, not `gigs.*` and full participant/organization rows;
+ *  - when `aroundDate` is given it only returns gigs whose `start` falls within
+ *    ±`windowDays` of that date, so linking an expense doesn't pull the org's
+ *    entire gig history (the source of the ~45s dropdown stall).
+ *
+ * `ensureGigId`, when supplied, is always included even if it's outside the
+ * window, so an already-linked gig still renders its label.
+ */
+export async function getGigOptionsForOrganization(
+  organizationId: string,
+  opts: { aroundDate?: string | null; windowDays?: number; ensureGigId?: string | null } = {}
+): Promise<GigOption[]> {
+  const supabase = getSupabase();
+  try {
+    const { data: participatingGigs, error: participantError } = await supabase
+      .from('gig_participants')
+      .select('gig_id')
+      .eq('organization_id', organizationId);
+
+    if (participantError) throw participantError;
+    if (!participatingGigs?.length) return [];
+
+    const gigIds = participatingGigs.map((pg: any) => pg.gig_id);
+
+    let query = supabase
+      .from('gigs')
+      .select('id, title, start, participants:gig_participants(role, organization:organization_id(name))')
+      .in('id', gigIds);
+
+    const { aroundDate, windowDays = GIG_PICKER_WINDOW_DAYS, ensureGigId } = opts;
+    const center = aroundDate ? new Date(aroundDate) : null;
+    if (center && !Number.isNaN(center.getTime())) {
+      const lo = new Date(center);
+      lo.setUTCDate(lo.getUTCDate() - windowDays);
+      lo.setUTCHours(0, 0, 0, 0);
+      const hi = new Date(center);
+      hi.setUTCDate(hi.getUTCDate() + windowDays);
+      hi.setUTCHours(23, 59, 59, 999);
+      const inWindow = `and(start.gte.${lo.toISOString()},start.lte.${hi.toISOString()})`;
+      query = query.or(ensureGigId ? `${inWindow},id.eq.${ensureGigId}` : inWindow);
+    }
+
+    const { data: gigs, error } = await query.order('start', { ascending: false });
+    if (error) throw error;
+
+    return (gigs || []).map((gig: any) => ({
+      id: gig.id,
+      title: gig.title,
+      start: gig.start,
+      venue: gig.participants?.find((p: any) => p.role === 'Venue')?.organization ?? null,
+      act: gig.participants?.find((p: any) => p.role === 'Act')?.organization ?? null,
+    }));
+  } catch (err) {
+    return handleApiError(err, 'fetch gig options for organization');
+  }
+}
+
 /**
  * Fetch a single gig with all its details (participants, staff slots, assignments, kits, bids)
  */

--- a/src/services/purchase.service.test.ts
+++ b/src/services/purchase.service.test.ts
@@ -286,7 +286,9 @@ describe('purchase → gig ledger lifecycle', () => {
   const line = (over: Partial<any> = {}) => ({
     id: 'line-1',
     row_type: 'item',
-    line_amount: 200,
+    line_cost: 200,
+    item_cost: null,
+    line_amount: null,
     item_price: null,
     quantity: null,
     purchase_date: '2026-02-01',
@@ -301,14 +303,40 @@ describe('purchase → gig ledger lifecycle', () => {
   });
 
   describe('purchaseLineLedgerAmount', () => {
-    it('uses line_amount when present', () => {
-      expect(purchaseLineLedgerAmount({ line_amount: 200, item_price: 5, quantity: 3 })).toBe(200);
+    it('uses line_cost (burdened total) first — even when a price is also present', () => {
+      expect(purchaseLineLedgerAmount({
+        line_cost: 66.73, item_cost: 66.73, line_amount: 60, item_price: 60, quantity: 1,
+      })).toBe(66.73);
     });
-    it('falls back to item_price × quantity', () => {
-      expect(purchaseLineLedgerAmount({ line_amount: null, item_price: 5, quantity: 3 })).toBe(15);
+    it('falls back to item_cost × quantity when line_cost is null', () => {
+      expect(purchaseLineLedgerAmount({
+        line_cost: null, item_cost: 25, line_amount: null, item_price: null, quantity: 4,
+      })).toBe(100);
+    });
+    it('records the pre-fee price only when no cost is stored', () => {
+      expect(purchaseLineLedgerAmount({
+        line_cost: null, item_cost: null, line_amount: 200, item_price: 5, quantity: 3,
+      })).toBe(200);
+      expect(purchaseLineLedgerAmount({
+        line_cost: null, item_cost: null, line_amount: null, item_price: 5, quantity: 3,
+      })).toBe(15);
+    });
+    it('does not return $0 for a scanned "cost" expense line (regression)', () => {
+      // line_amount / item_price are null on imported/scanned expenses; the value
+      // lives in line_cost. The old logic recorded $0 here.
+      expect(purchaseLineLedgerAmount({
+        line_cost: 66.73, item_cost: null, line_amount: null, item_price: null, quantity: 1,
+      })).toBe(66.73);
     });
     it('treats a missing quantity as 1', () => {
-      expect(purchaseLineLedgerAmount({ line_amount: null, item_price: 7, quantity: null })).toBe(7);
+      expect(purchaseLineLedgerAmount({
+        line_cost: null, item_cost: null, line_amount: null, item_price: 7, quantity: null,
+      })).toBe(7);
+    });
+    it('is 0-safe when the line carries no amount at all', () => {
+      expect(purchaseLineLedgerAmount({
+        line_cost: null, item_cost: null, line_amount: null, item_price: null, quantity: null,
+      })).toBe(0);
     });
   });
 

--- a/src/services/purchase.service.ts
+++ b/src/services/purchase.service.ts
@@ -511,12 +511,30 @@ export function shouldPromptForLedgerEntry(
 /** The subset of a purchase line needed to build/refresh its ledger entry. */
 export type LedgerLineSource = Pick<
   DbPurchase,
-  'id' | 'row_type' | 'line_amount' | 'item_price' | 'quantity' | 'purchase_date' | 'description' | 'vendor' | 'category'
+  | 'id' | 'row_type' | 'line_cost' | 'item_cost' | 'line_amount' | 'item_price'
+  | 'quantity' | 'purchase_date' | 'description' | 'vendor' | 'category'
 >;
 
-/** Amount a purchase line contributes to a gig ledger: explicit line total, else price × qty. */
-export function purchaseLineLedgerAmount(item: Pick<DbPurchase, 'line_amount' | 'item_price' | 'quantity'>): number {
-  return item.line_amount ?? (item.item_price ?? 0) * (item.quantity ?? 1);
+/**
+ * Amount a purchase line contributes to a gig ledger.
+ *
+ * `line_cost` is the burdened line total that cost allocation reconciles to the
+ * invoice (see `applyCostAllocation`), so it's the authoritative figure for an
+ * "Expense Incurred" entry. "Cost" rows (imported/scanned expenses) only carry
+ * `line_cost`/`item_cost` — `line_amount`/`item_price` are null for them, which
+ * is why the old `line_amount`-first logic recorded $0. Fall back to the pre-fee
+ * price only when no cost is stored.
+ */
+export function purchaseLineLedgerAmount(
+  item: Pick<DbPurchase, 'line_cost' | 'item_cost' | 'line_amount' | 'item_price' | 'quantity'>
+): number {
+  const qty = item.quantity ?? 1;
+  return (
+    item.line_cost ??
+    (item.item_cost != null ? item.item_cost * qty : null) ??
+    item.line_amount ??
+    (item.item_price ?? 0) * qty
+  );
 }
 
 /** Build the `createGigFinancial` payload for a purchase line linked to a gig. */


### PR DESCRIPTION
Three production issues in **Purchases → Assign Gig**.

## 1. Ledger entries recorded $0 for scanned/imported expenses
`purchaseLineLedgerAmount()` read `line_amount ?? item_price × qty`. Scanned invoices and CSV "cost" rows populate only `line_cost`/`item_cost` and leave `line_amount`/`item_price` null, so it computed `0`. Now prefers the burdened `line_cost` (then `item_cost × qty`), falling back to price only when no cost is stored. Fixes both the "Create gig expense record?" dialog amount and the `gig_financials` row that gets written.

Existing $0 rows are **not** retroactively corrected (deliberate — per request).

## 2. Assign Gig dropdown took ~45s
`GigCombobox` called `getGigsForOrganization()` — `gigs.*` plus full nested participant/organization rows, the org's entire gig history — on every mount, once per receipt header and once per expanded line.

New `getGigOptionsForOrganization()`:
- selects only `id, title, start` + venue/act name
- when given a reference date, returns only gigs starting within ±`GIG_PICKER_WINDOW_DAYS` (21) of it, always keeping the currently-linked gig

`GigCombobox` gains an `aroundDate` prop; `PurchasesTab` passes the line's / receipt's `purchase_date`. The popover shows a "Showing gigs near <date>" footer. The summary-view name map also uses the lighter query.

## 3. "Add to gig ledger" button overlapping the selector
The trigger `<Button>` carries `shrink-0` + `whitespace-nowrap` from its variant; with `flex-1` and no `min-width:0` it grew to the full label width and painted over the sibling button. Added `min-w-0 shrink` to the trigger and `min-w-0` to the combobox root so `.truncate` clips.

## Tests
- New unit tests: amount fallback chain (incl. the scanned-expense regression), date-window `.or()` filter + venue/act mapping
- Full suite green (`TZ=UTC`, 715 passing); `tsc --noEmit` and `eslint` clean
- Manual smoke steps 1.5 / 1.6 added to the checklist doc
- Not verified against the live UI (needs a logged-in session + a gig-linked scanned expense)

🤖 Generated with [Claude Code](https://claude.com/claude-code)