### PR TITLE
Fix Gig View not refreshing after editing a financial record

### DIFF
--- a/src/components/gig/GigFinancialsSection.test.tsx
+++ b/src/components/gig/GigFinancialsSection.test.tsx
@@ -4,6 +4,7 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GigFinancialsSection from './GigFinancialsSection';
 import * as gigService from '../../services/gig.service';
+import { useAutoSave } from '../../utils/hooks/useAutoSave';
 
 // The component now uses TanStack Query, so renders need a QueryClientProvider.
 // retry:false keeps tests deterministic and fast.
@@ -23,12 +24,13 @@ vi.mock('../../services/gig.service', () => ({
   getGigProfitabilitySummary: vi.fn(),
 }));
 
-// Mock the useAutoSave hook
+// Mock the useAutoSave hook. Default behavior is a no-op triggerSave, matching
+// the pre-existing tests below (which don't exercise the real save path).
+// Individual regression tests override this with mockImplementation to drive
+// the component's real onSave/onSuccess callbacks deterministically, without
+// depending on the hook's internal debounce timer.
 vi.mock('../../utils/hooks/useAutoSave', () => ({
-  useAutoSave: () => ({
-    saveState: 'saved',
-    triggerSave: vi.fn(),
-  }),
+  useAutoSave: vi.fn(),
 }));
 
 // Mock the SaveStateIndicator component
@@ -82,6 +84,13 @@ describe('GigFinancialsSection', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(useAutoSave).mockReturnValue({
+      saveState: 'saved',
+      error: null,
+      triggerSave: vi.fn(),
+      flush: vi.fn(),
+      flushAsync: vi.fn(),
+    });
     vi.mocked(gigService.getGigFinancials).mockResolvedValue(mockFinancials as unknown as Awaited<ReturnType<typeof gigService.getGigFinancials>>);
     vi.mocked(gigService.updateGigFinancials).mockResolvedValue({ success: true });
     vi.mocked(gigService.deleteGigFinancial).mockResolvedValue({ success: true });
@@ -279,10 +288,126 @@ describe('GigFinancialsSection', () => {
 
   it('shows save state indicator', async () => {
     render(<GigFinancialsSection {...defaultProps} />);
-    
+
     await waitFor(() => {
       expect(screen.getByTestId('save-indicator')).toBeInTheDocument();
       expect(screen.getByTestId('save-indicator')).toHaveTextContent('saved');
+    });
+  });
+
+  describe('gig view refresh after editing a financial record (issue #8)', () => {
+    // Mirrors the app's real QueryClient config (src/lib/queryClient.ts):
+    // a 30s staleTime is exactly what let a remounted view keep serving
+    // pre-edit data when the mutation only refetched the summary query.
+    function makeProdLikeQueryClient() {
+      return new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, staleTime: 30_000, refetchOnWindowFocus: false },
+          mutations: { retry: false },
+        },
+      });
+    }
+
+    function renderWithClient(queryClient: QueryClient) {
+      return rtlRender(
+        <QueryClientProvider client={queryClient}>
+          <GigFinancialsSection {...defaultProps} />
+        </QueryClientProvider>
+      );
+    }
+
+    it('shows the edited amount after the section remounts (e.g. a tab switch)', async () => {
+      // Drive the component's real onSave/onSuccess synchronously, bypassing
+      // the debounce timer, so the test exercises the actual save path
+      // instead of the no-op default mock.
+      vi.mocked(useAutoSave).mockImplementation(({ onSave, onSuccess }: any) => ({
+        saveState: 'saved',
+        error: null,
+        triggerSave: (data: any) => {
+          void onSave(data).then(() => onSuccess?.(data));
+        },
+        flush: vi.fn(),
+        flushAsync: vi.fn(),
+      }));
+
+      const updatedFinancials = [
+        { ...mockFinancials[0], amount: 9999 },
+        mockFinancials[1],
+      ];
+      vi.mocked(gigService.getGigFinancials)
+        .mockResolvedValueOnce(mockFinancials as any)
+        .mockResolvedValue(updatedFinancials as any);
+
+      const queryClient = makeProdLikeQueryClient();
+
+      // "Initial payment" (fin-1's description) is unique text, unlike the amount which
+      // also appears in the summary panel — use it to scope assertions to the actual row.
+      const getRow = () => screen.getByText('Initial payment').closest('tr') as HTMLElement;
+
+      const first = renderWithClient(queryClient);
+      await waitFor(() => expect(getRow()).toHaveTextContent('$5,000.00'));
+
+      fireEvent.click(screen.getByText('Edit Financials'));
+      await waitFor(() => expect(screen.getByTestId('edit-financial-0')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('edit-financial-0'));
+      await waitFor(() => expect(screen.getByText('Edit Financial Record')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '9999' } });
+      fireEvent.click(screen.getByText('Update Financial Record'));
+
+      await waitFor(() => expect(gigService.updateGigFinancials).toHaveBeenCalled());
+      // Regression: useFieldArray's `fields` (what the table renders from) only resyncs on a
+      // plain reset, which the pre-fix handleSaveSuccess skipped via `keepValues: true` — so
+      // even this same mounted instance kept showing the pre-edit amount until something else
+      // (e.g. a remount) forced a real reset.
+      await waitFor(() => expect(getRow()).toHaveTextContent('$9,999.00'));
+
+      // Simulate leaving and returning to the Gig View (e.g. a tab switch unmounts this section).
+      first.unmount();
+      renderWithClient(queryClient);
+
+      // Regression: without invalidating the financials query cache on save, this remount
+      // would serve the stale pre-edit $5,000.00 from the still-fresh (staleTime: 30s) cache.
+      await waitFor(() => expect(getRow()).toHaveTextContent('$9,999.00'));
+      expect(getRow()).not.toHaveTextContent('$5,000.00');
+    });
+
+    it('does not let a concurrent background refresh clobber an in-progress dirty edit', async () => {
+      // Default no-op triggerSave (from beforeEach): the edit becomes dirty (isDirty: true)
+      // but autosave never fires, simulating a pending edit still within its debounce window
+      // (or blocked on a slow save elsewhere) when a concurrent, unrelated change lands.
+      const queryClient = makeProdLikeQueryClient();
+
+      const externallyUpdatedFinancials = [
+        { ...mockFinancials[0], amount: 7777 },
+        mockFinancials[1],
+      ];
+      vi.mocked(gigService.getGigFinancials)
+        .mockResolvedValueOnce(mockFinancials as any)
+        .mockResolvedValue(externallyUpdatedFinancials as any);
+
+      const getRow = () => screen.getByText('Initial payment').closest('tr') as HTMLElement;
+
+      renderWithClient(queryClient);
+      await waitFor(() => expect(getRow()).toHaveTextContent('$5,000.00'));
+
+      fireEvent.click(screen.getByText('Edit Financials'));
+      await waitFor(() => expect(screen.getByTestId('edit-financial-0')).toBeInTheDocument());
+      fireEvent.click(screen.getByTestId('edit-financial-0'));
+      await waitFor(() => expect(screen.getByText('Edit Financial Record')).toBeInTheDocument());
+
+      fireEvent.change(screen.getByLabelText('Amount'), { target: { value: '9999' } });
+      fireEvent.click(screen.getByText('Update Financial Record'));
+
+      // A background event (e.g. another user editing the same gig, or staff finalization
+      // elsewhere) refetches the financials query while this row is a dirty, unsaved edit.
+      window.dispatchEvent(new CustomEvent('gig-financials-updated', { detail: { gigId: 'test-gig-id' } }));
+      await waitFor(() => expect(gigService.getGigFinancials).toHaveBeenCalledTimes(2));
+
+      // Regression: without the isDirty guard, the sync effect would apply the freshly
+      // refetched external data ($7,777) over the in-progress local edit, discarding it.
+      expect(getRow()).not.toHaveTextContent('$7,777.00');
+      expect(getRow()).toHaveTextContent('$5,000.00');
     });
   });
 });

--- a/src/components/gig/GigFinancialsSection.tsx
+++ b/src/components/gig/GigFinancialsSection.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {useForm, useFieldArray } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -16,6 +17,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import OrganizationSelector from '../OrganizationSelector';
 import { updateGigFinancials } from '../../services/gig.service';
 import { useGigFinancialsData, useDeleteGigFinancial } from './useGigFinancialsData';
+import { queryKeys } from '../../lib/queryKeys';
 import { scanInvoice } from '../../services/purchase.service';
 import ReviewScannedDataDialog from '../ReviewScannedDataDialog';
 import { useAutoSave } from '../../utils/hooks/useAutoSave';
@@ -128,6 +130,7 @@ export default function GigFinancialsSection({
   gigStartDate,
 }: GigFinancialsSectionProps) {
   const navigation = useNavigation();
+  const queryClient = useQueryClient();
   const [showFinancialModal, setShowFinancialModal] = useState(false);
   const [currentFinancialIndex, setCurrentFinancialIndex] = useState<number | null>(null);
   const [selectedCounterparty, setSelectedCounterparty] = useState<any>(null);
@@ -220,12 +223,23 @@ export default function GigFinancialsSection({
       purchase_id: f.purchase_id || undefined,
       staff_assignment_id: f.staff_assignment_id || undefined,
     })));
+    // Refresh the financials query cache so other mounted instances of this
+    // section (or a later remount, e.g. switching Gig View tabs) pick up the
+    // saved data instead of serving it from the pre-edit cache (issue #8).
+    // This mounted instance's own display is resynced directly in
+    // handleSaveSuccess below, so this doesn't need to be awaited.
+    void queryClient.invalidateQueries({ queryKey: queryKeys.financials(gigId) });
     void summaryQuery.refetch();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gigId, currentOrganizationId]);
+  }, [gigId, currentOrganizationId, queryClient]);
 
   const handleSaveSuccess = useCallback((data: FinancialsFormInput) => {
-    reset(data, { keepDirty: false, keepValues: true });
+    // A plain reset (no `keepValues`) is required here: useFieldArray's `fields`
+    // (what the table renders from) only resyncs to current values on a full
+    // reset, not on a per-field setValue — so `keepValues: true` was silently
+    // leaving the displayed rows on their pre-edit values until an unrelated
+    // full reset happened to fire (e.g. a query refetch).
+    reset(data, { keepDirty: false });
   }, [reset]);
 
   const { saveState, triggerSave } = useAutoSave<FinancialsFormInput>({
@@ -260,10 +274,13 @@ export default function GigFinancialsSection({
     }
   }, [formValues, isDirty, triggerSave]);
 
-  // Sync the form from the financials query on initial load and explicit
-  // refetches. The query is never invalidated by mutations, so this cannot
-  // clobber in-progress edits / autosave.
+  // Sync the form from the financials query on initial load and whenever it
+  // refetches (including the invalidation this component's own save now
+  // triggers, and external refetches like the 'gig-financials-updated'
+  // event). Skip while the form is dirty so a save still in flight elsewhere,
+  // or another concurrent edit, can't clobber an in-progress local edit.
   useEffect(() => {
+    if (isDirty) return;
     const data = financialsQuery.data;
     if (!data) return;
     const loadedFinancials = data.map((f: any) => ({
@@ -286,7 +303,7 @@ export default function GigFinancialsSection({
     }));
     reset({ financials: loadedFinancials });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [financialsQuery.data]);
+  }, [financialsQuery.data, isDirty]);
 
   const refetchAll = useCallback(() => {
     void financialsQuery.refetch();


### PR DESCRIPTION
## Summary

Fixes #8. Edits to a financial record were saving correctly, but the Gig View wasn't reflecting them.

Two compounding bugs in `GigFinancialsSection.tsx`:

- The `financials` React Query cache was never invalidated after a save (only the summary query was). Under the app's 30s `staleTime`, a remounted instance (e.g. switching Gig View tabs) kept serving pre-edit data indefinitely.
- The post-save `reset(data, { keepDirty: false, keepValues: true })` call used `keepValues: true`, which skips resyncing `useFieldArray`'s `fields` — the state the table actually renders from. So even the *same* mounted instance kept showing the pre-edit amount until something unrelated forced a full reset.

## Changes

- Drop `keepValues` from the post-save reset so the edited row displays immediately in the same instance.
- Invalidate the `financials` query cache on save so other mounted instances / later remounts pick up fresh data.
- Guard the query-data sync effect to skip while the form is dirty, preserving the original protection against a concurrent background refetch clobbering an in-progress edit.

## Test plan

- [x] Added a failing-first regression test reproducing the exact reported bug (edit a record, remount the section with a QueryClient configured like the production one — 30s `staleTime` — and confirm the new value survives the remount instead of reverting to stale cached data).
- [x] Added a second regression test for the inverse case: a concurrent background refetch (e.g. the `gig-financials-updated` event) must not clobber a still-dirty, unsaved local edit.
- [x] Full test suite: `npx vitest run` — 738/738 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [x] Manual verification in a live dev environment — **not performed**; this sandbox has no Supabase credentials (`.env.local`) to run the app against real data. The regression tests exercise the exact reported scenario (edit → remount) against a QueryClient configured identically to `src/lib/queryClient.ts`, so I'm confident in the fix, but a manual click-through in a running dev instance would still be worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JH93mrdMn9nyhBYGYbieom

---
_Generated by [Claude Code](https://claude.ai/code/session_01JH93mrdMn9nyhBYGYbieom)_