### PR TITLE
Separate upcoming/past gigs on web list and improve filter icon visibility

### DIFF
--- a/src/components/GigListScreen.test.tsx
+++ b/src/components/GigListScreen.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GigListScreen from './GigListScreen';
+
+const now = Date.now();
+const futureGig = {
+  id: 'gig-future',
+  title: 'Upcoming Show',
+  status: 'Booked',
+  start: new Date(now + 86400000).toISOString(),
+  end: new Date(now + 90000000).toISOString(),
+  timezone: 'America/New_York',
+  tags: [],
+  notes: '',
+  venue: null,
+  act: null,
+};
+const pastGig = {
+  id: 'gig-past',
+  title: 'Old Show',
+  status: 'Completed',
+  start: new Date(now - 172800000).toISOString(),
+  end: new Date(now - 168000000).toISOString(),
+  timezone: 'America/New_York',
+  tags: [],
+  notes: '',
+  venue: null,
+  act: null,
+};
+
+vi.mock('../services/gig.service', () => ({
+  getGigsForOrganization: vi.fn(),
+  updateGig: vi.fn(),
+  duplicateGig: vi.fn(),
+  deleteGig: vi.fn(),
+  getGigExportAggregates: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock('../services/conflictDetection.service', () => ({
+  checkAllConflictsForGigs: vi.fn().mockResolvedValue([]),
+}));
+
+import { getGigsForOrganization } from '../services/gig.service';
+
+const organization = { id: 'org-1', name: 'Test Org' } as any;
+const user = { id: 'user-1', name: 'Test User' } as any;
+
+const noop = () => {};
+
+describe('GigListScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    vi.mocked(getGigsForOrganization).mockResolvedValue([futureGig, pastGig]);
+  });
+
+  it('shows Upcoming gigs by default and hides Past gigs', async () => {
+    render(
+      <GigListScreen
+        organization={organization}
+        user={user}
+        userRole="Admin"
+        onBack={noop}
+        onCreateGig={noop}
+        onViewGig={noop}
+        onEditGig={noop}
+        onNavigateToDashboard={noop}
+        onNavigateToGigs={noop}
+        onNavigateToAssets={noop}
+        onSwitchOrganization={noop}
+        onLogout={noop}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Upcoming Show')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Old Show')).not.toBeInTheDocument();
+  });
+
+  it('shows Past gigs and hides Upcoming gigs when the Past tab is selected', async () => {
+    const ue = userEvent.setup();
+    render(
+      <GigListScreen
+        organization={organization}
+        user={user}
+        userRole="Admin"
+        onBack={noop}
+        onCreateGig={noop}
+        onViewGig={noop}
+        onEditGig={noop}
+        onNavigateToDashboard={noop}
+        onNavigateToGigs={noop}
+        onNavigateToAssets={noop}
+        onSwitchOrganization={noop}
+        onLogout={noop}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Upcoming Show')).toBeInTheDocument();
+    });
+
+    await ue.click(screen.getByText('Past (1)'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Old Show')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Upcoming Show')).not.toBeInTheDocument();
+  });
+
+  it('labels the tabs with the count of gigs in each timeframe', async () => {
+    render(
+      <GigListScreen
+        organization={organization}
+        user={user}
+        userRole="Admin"
+        onBack={noop}
+        onCreateGig={noop}
+        onViewGig={noop}
+        onEditGig={noop}
+        onNavigateToDashboard={noop}
+        onNavigateToGigs={noop}
+        onNavigateToAssets={noop}
+        onSwitchOrganization={noop}
+        onLogout={noop}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Upcoming (1)')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Past (1)')).toBeInTheDocument();
+  });
+});

--- a/src/components/GigListScreen.tsx
+++ b/src/components/GigListScreen.tsx
@@ -122,6 +122,7 @@ export default function GigListScreen({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
+  const [gigTimeframe, setGigTimeframe] = useState<'upcoming' | 'past'>('upcoming');
   const [showExportConfirm, setShowExportConfirm] = useState(false);
   // Rows the list table is actually showing (date/status filters + per-column
   // filters + sort applied). Fed by SmartDataTable's onFilteredDataChange; drives
@@ -184,6 +185,20 @@ export default function GigListScreen({
     }
     return result;
   }, [gigs, futureDateFilter, pastDateFilter, activeStatuses]);
+
+  // Mirrors the mobile gig list's Upcoming/Past split (see MobileGigList.tsx)
+  // so the web list separates future and past gigs the same way.
+  const { upcomingGigs, pastGigs } = useMemo(() => {
+    const now = new Date();
+    const upcoming: Gig[] = [];
+    const past: Gig[] = [];
+    for (const gig of filteredGigs) {
+      (new Date(gig.start) >= now ? upcoming : past).push(gig);
+    }
+    return { upcomingGigs: upcoming, pastGigs: past };
+  }, [filteredGigs]);
+
+  const timeframeGigs = gigTimeframe === 'upcoming' ? upcomingGigs : pastGigs;
 
   const handleGigDuplicate = useCallback(async (gigId: string) => {
     try {
@@ -580,6 +595,12 @@ export default function GigListScreen({
 
   const dateFilterControl = (
     <div className="flex items-center gap-2">
+      <Tabs value={gigTimeframe} onValueChange={(v) => setGigTimeframe(v as 'upcoming' | 'past')}>
+        <TabsList>
+          <TabsTrigger value="upcoming">Upcoming ({upcomingGigs.length})</TabsTrigger>
+          <TabsTrigger value="past">Past ({pastGigs.length})</TabsTrigger>
+        </TabsList>
+      </Tabs>
       <GigDateFilterDropdown
         futureDateFilter={futureDateFilter}
         pastDateFilter={pastDateFilter}
@@ -719,7 +740,7 @@ export default function GigListScreen({
                 )}
                 <SmartDataTable
                   tableId="gig-list"
-                  data={filteredGigs}
+                  data={timeframeGigs}
                   columns={gigColumns}
                   rowActions={rowActions}
                   onRowUpdate={canEdit ? handleRowUpdate : undefined}
@@ -727,7 +748,7 @@ export default function GigListScreen({
                   onFilteredDataChange={setExportRows}
                   onVisibleColumnsChange={setVisibleColumnIds}
                   isLoading={isLoading}
-                  emptyMessage="No gigs found"
+                  emptyMessage={gigTimeframe === 'upcoming' ? 'No upcoming gigs found' : 'No past gigs found'}
                   toolbarLeft={dateFilterControl}
                 />
               </>

--- a/src/components/tables/SmartDataTable.test.tsx
+++ b/src/components/tables/SmartDataTable.test.tsx
@@ -320,6 +320,66 @@ describe('SmartDataTable', () => {
     expect(setFilter).toHaveBeenCalledWith('name', 'i');
   });
 
+  it('gives the filter icon a filled "on" state when a column filter is active', async () => {
+    const { useTableState } = await import('../../utils/hooks/useTableState');
+    const mockUseTableState = vi.mocked(useTableState);
+
+    mockUseTableState.mockReturnValue({
+      sorting: null,
+      filters: { name: 'Ali' },
+      columnVisibility: {},
+      columnWidths: {},
+      toggleSorting: vi.fn(),
+      setFilter: vi.fn(),
+      removeFilter: vi.fn(),
+      toggleColumnVisibility: vi.fn(),
+      setColumnWidth: vi.fn(),
+    } as any);
+
+    render(
+      <SmartDataTable
+        tableId="test-table"
+        data={data}
+        columns={columns}
+      />
+    );
+
+    const filterButton = screen.getByLabelText('Filter Name');
+    expect(filterButton.className).toContain('bg-primary');
+    const filterIcon = filterButton.querySelector('svg');
+    expect(filterIcon).toHaveAttribute('fill', 'currentColor');
+  });
+
+  it('leaves the filter icon unfilled when no column filter is active', async () => {
+    const { useTableState } = await import('../../utils/hooks/useTableState');
+    const mockUseTableState = vi.mocked(useTableState);
+
+    mockUseTableState.mockReturnValue({
+      sorting: null,
+      filters: {},
+      columnVisibility: {},
+      columnWidths: {},
+      toggleSorting: vi.fn(),
+      setFilter: vi.fn(),
+      removeFilter: vi.fn(),
+      toggleColumnVisibility: vi.fn(),
+      setColumnWidth: vi.fn(),
+    } as any);
+
+    render(
+      <SmartDataTable
+        tableId="test-table"
+        data={data}
+        columns={columns}
+      />
+    );
+
+    const filterButton = screen.getByLabelText('Filter Name');
+    expect(filterButton.className).not.toContain('bg-primary');
+    const filterIcon = filterButton.querySelector('svg');
+    expect(filterIcon).toHaveAttribute('fill', 'none');
+  });
+
   it('calls toggleSorting when clicking a sortable column header', async () => {
     const user = userEvent.setup();
     const { useTableState } = await import('../../utils/hooks/useTableState');

--- a/src/components/tables/SmartDataTable.tsx
+++ b/src/components/tables/SmartDataTable.tsx
@@ -586,16 +586,18 @@ export function SmartDataTable<T extends { id: string }>({
                     {column.filterable && (
                       <Popover>
                         <PopoverTrigger asChild>
-                          <Button 
-                            variant="ghost" 
-                            size="sm" 
+                          <Button
+                            variant="ghost"
+                            size="sm"
                             aria-label={`Filter ${column.header}`}
                             className={cn(
-                              "h-5 w-5 p-0 shrink-0", 
-                              filters[column.id] && "text-primary"
+                              "h-5 w-5 p-0 shrink-0 rounded-full",
+                              filters[column.id]
+                                ? "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground"
+                                : "text-muted-foreground"
                             )}
                           >
-                            <Filter className="h-3 w-3" />
+                            <Filter className="h-3 w-3" fill={filters[column.id] ? "currentColor" : "none"} />
                           </Button>
                         </PopoverTrigger>
                         <PopoverContent className="w-60 p-2" align="start">


### PR DESCRIPTION
## Summary

Implements #7 (separate future and past gigs in the web gig list) and #6 (make the active-filter indicator on `SmartDataTable` easier to see).

### #7 — Upcoming/Past split on the web gig list

`GigListScreen` showed every gig in one flat table, unlike the mobile app which already splits into "Upcoming" / "Past" sections. Added an Upcoming/Past tab control (`Tabs`/`TabsList`/`TabsTrigger`, matching the existing Month/Week calendar-view tabs pattern in this same file) above the list, defaulting to Upcoming:

- Gigs are split by comparing `start` against "now", after the existing date/status filters are applied — same logic mobile's `MobileGigList.tsx` already uses.
- Tab labels show live counts, e.g. "Upcoming (12)" / "Past (34)".
- Export and the Columns menu are unaffected — they still operate on whatever the table is currently showing (i.e., the selected tab), consistent with the existing "exports exactly what the list is currently showing" behavior.
- Empty-state message is now timeframe-aware ("No upcoming gigs found" / "No past gigs found").

### #6 — Filter icon "on" state

The funnel icon in `SmartDataTable`'s column headers only changed text color (`text-primary`) when a filter was active — easy to miss. It now gets a filled circular badge (`bg-primary` background) and the icon itself is filled (`fill="currentColor"`) when a filter is active, so the on/off state reads clearly at a glance.

### Test plan

- [x] Added `GigListScreen.test.tsx`: verifies gigs default to the Upcoming tab, past gigs are hidden until the Past tab is selected (and vice versa), and tab counts are correct.
- [x] Added two `SmartDataTable.test.tsx` cases: filter icon gets the filled/`bg-primary` state when a column filter is active, and stays unfilled when it isn't.
- [x] Full suite: `npx vitest run` — 746/746 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean (pre-existing, unrelated `loadGigs` dependency warnings in `GigListScreen.tsx` only).
- [ ] Manual click-through not performed in this sandbox (no way to run the dev server against a real Supabase instance here) — worth a quick look at both entry points before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126SEcf4GHPNLWmE5bCsgeL

---
_Generated by [Claude Code](https://claude.ai/code/session_0126SEcf4GHPNLWmE5bCsgeL)_