### PR TITLE
Diagnose and prevent Google Calendar sync permission failures

### DIFF
--- a/docs/development/user-documentation-plan.md
+++ b/docs/development/user-documentation-plan.md
@@ -59,6 +59,11 @@ This plan outlines the structure and content for comprehensive user-facing docum
 - **Google Calendar Integration**:
     - Connecting your account.
     - Syncing Gigs to your personal or organization-wide calendar.
+    - **Choosing a calendar you can actually write to**: only calendars you own or have "Make changes to
+      events" access on are shown in the picker — if you want to sync to a shared/team calendar you don't
+      own, its owner needs to grant that access first, or connect using the owner's Google account instead.
+      A calendar that loses write access after being selected shows a warning here and blocks "Sync All
+      Gigs" until it's resolved (see issue #9).
 - **Conflict Detection**: How the system warns about overlapping schedules.
 
 ### 8. Mobile App & Field Operations

--- a/docs/technical/setup-guide.md
+++ b/docs/technical/setup-guide.md
@@ -318,6 +318,25 @@ supabase secrets set GOOGLE_CLIENT_ID=your-google-client-id
 supabase secrets set GOOGLE_CLIENT_SECRET=your-google-client-secret
 ```
 
+#### Per-user calendar write access (not an app config step, but a common support issue)
+OAuth scope and calendar sharing are two separate permission layers in Google Calendar, and users
+routinely trip over this: the app already requests the full `https://www.googleapis.com/auth/calendar`
+scope, which lets a connected account attempt writes on *any* calendar it can see — but each individual
+calendar also has its own sharing/ACL role, and Google enforces that independently of scope. A user can
+be "Connected" and have a calendar selected while only holding **read** access on it (e.g. "See all event
+details"), and every sync will then fail with a `403 Forbidden` / `"You need to have writer access to this
+calendar."` error from Google's API (see issue #9).
+
+If a user reports Google Calendar sync failing for every gig, check first whether they have write access
+to the calendar they selected:
+- Simplest fix: connect using the Google account that **owns** the target calendar.
+- Or: in Google Calendar's settings for that calendar → **Share with specific people** → give the
+  connected account **"Make changes to events"** access (or higher).
+
+The app's calendar picker only offers calendars where Google reports `accessRole` as `writer` or `owner`,
+and shows a warning if a previously-selected calendar's access has since been downgraded — but it can't
+detect or fix a sharing permission that was never granted in the first place.
+
 ### 4. Secrets Management
 - **List Secrets**: `supabase secrets list`
 - **Set Secret**: `supabase secrets set NAME=VALUE`

--- a/src/components/CalendarIntegrationSettings.test.tsx
+++ b/src/components/CalendarIntegrationSettings.test.tsx
@@ -228,6 +228,39 @@ describe('CalendarIntegrationSettings', () => {
     expect(screen.getByText('No sync activity yet')).toBeInTheDocument();
   });
 
+  it('warns when the selected calendar is read-only and disables Sync All Gigs (issue #9)', async () => {
+    (calService.getUserGoogleCalendarSettings as ReturnType<typeof vi.fn>).mockResolvedValue(mockSettings);
+    (calService.getUserCalendars as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: 'cal-1', name: 'My Calendar', primary: true, accessRole: 'reader' },
+    ]);
+    (calService.getSyncLogs as ReturnType<typeof vi.fn>).mockResolvedValue(mockSyncLogs);
+    (calService.getSyncStatusSummary as ReturnType<typeof vi.fn>).mockResolvedValue(mockSyncSummary);
+
+    render(<CalendarIntegrationSettings userId="user-1" organizationId="org-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/you only have read access to/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: /^sync all gigs$/i })).toBeDisabled();
+  });
+
+  it('does not warn when the selected calendar is writable', async () => {
+    (calService.getUserGoogleCalendarSettings as ReturnType<typeof vi.fn>).mockResolvedValue(mockSettings);
+    (calService.getUserCalendars as ReturnType<typeof vi.fn>).mockResolvedValue(mockCalendars);
+    (calService.getSyncLogs as ReturnType<typeof vi.fn>).mockResolvedValue(mockSyncLogs);
+    (calService.getSyncStatusSummary as ReturnType<typeof vi.fn>).mockResolvedValue(mockSyncSummary);
+
+    render(<CalendarIntegrationSettings userId="user-1" organizationId="org-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Connected to Google Calendar')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/you only have read access to/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^sync all gigs$/i })).not.toBeDisabled();
+  });
+
   it('does not render sync sections when disconnected', async () => {
     (calService.getUserGoogleCalendarSettings as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 

--- a/src/components/CalendarIntegrationSettings.tsx
+++ b/src/components/CalendarIntegrationSettings.tsx
@@ -61,6 +61,12 @@ interface SyncSummary {
 
 type SyncFrequency = 'realtime' | 'manual';
 
+// Google's calendar sharing model grants each calendar its own access role,
+// independent of OAuth scope — a calendar shared as "See all event details"
+// (reader) will 403 on every write even with full calendar-write scope
+// granted. Only these roles can actually create/update/delete events.
+const WRITABLE_ACCESS_ROLES = new Set(['writer', 'owner']);
+
 export default function CalendarIntegrationSettings({
   userId,
   organizationId,
@@ -369,6 +375,9 @@ export default function CalendarIntegrationSettings({
 
   const isConnected = !!(settings?.access_token);
   const displayedLogs = showAllLogs ? syncLogs : syncLogs.slice(0, 5);
+  const writableCalendars = availableCalendars.filter((cal) => WRITABLE_ACCESS_ROLES.has(cal.accessRole));
+  const selectedCalendar = availableCalendars.find((cal) => cal.id === settings?.calendar_id);
+  const selectedCalendarNotWritable = !!selectedCalendar && !WRITABLE_ACCESS_ROLES.has(selectedCalendar.accessRole);
 
   return (
     <div className="space-y-6">
@@ -494,7 +503,7 @@ export default function CalendarIntegrationSettings({
                       <SelectValue placeholder="Select a calendar" />
                     </SelectTrigger>
                     <SelectContent>
-                      {availableCalendars.map((calendar) => (
+                      {writableCalendars.map((calendar) => (
                         <SelectItem key={calendar.id} value={calendar.id}>
                           <div className="flex items-center gap-2">
                             {calendar.name}
@@ -514,7 +523,24 @@ export default function CalendarIntegrationSettings({
                       Loading calendars...
                     </p>
                   )}
+                  {!loadingCalendars && availableCalendars.length > 0 && writableCalendars.length === 0 && (
+                    <p className="text-sm text-muted-foreground">
+                      None of your Google calendars can be written to. Ask a calendar owner to share one with
+                      "Make changes to events" access, or connect using an account that owns a calendar.
+                    </p>
+                  )}
                 </div>
+
+                {selectedCalendarNotWritable && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>
+                      You only have read access to "{selectedCalendar?.name || settings.calendar_name}" — gigs can't
+                      be synced to it. Ask its owner to share it with "Make changes to events" access, connect using
+                      the calendar owner's Google account, or pick a different calendar you own.
+                    </AlertDescription>
+                  </Alert>
+                )}
 
                 <Alert>
                   <Settings className="h-4 w-4" />
@@ -630,7 +656,7 @@ export default function CalendarIntegrationSettings({
               <div className="flex items-center gap-4">
                 <Button
                   onClick={handleSyncNow}
-                  disabled={syncing || !settings?.calendar_id || !organizationId}
+                  disabled={syncing || !settings?.calendar_id || !organizationId || selectedCalendarNotWritable}
                 >
                   {syncing ? (
                     <>
@@ -647,6 +673,11 @@ export default function CalendarIntegrationSettings({
                 {!settings?.calendar_id && (
                   <p className="text-sm text-muted-foreground">
                     Select a calendar first
+                  </p>
+                )}
+                {settings?.calendar_id && selectedCalendarNotWritable && (
+                  <p className="text-sm text-destructive">
+                    Fix calendar access above before syncing
                   </p>
                 )}
               </div>

--- a/src/services/googleCalendar.service.test.ts
+++ b/src/services/googleCalendar.service.test.ts
@@ -171,6 +171,91 @@ describe('googleCalendar.service', () => {
     });
   });
 
+  describe('sync error diagnostics (issue #9 regression)', () => {
+    const mockSettings = {
+      id: 'settings-1',
+      user_id: 'user-123',
+      calendar_id: 'cal-123',
+      calendar_name: 'Act4Audio',
+      access_token: 'token-abc',
+      refresh_token: 'refresh-xyz',
+      token_expires_at: new Date(Date.now() + 3600000).toISOString(),
+      is_enabled: true,
+      sync_filters: {},
+    };
+
+    function makeFunctionsHttpError(body: any, status: number) {
+      const mockResponse = {
+        json: () => Promise.resolve(body),
+        clone: () => ({ json: () => Promise.resolve(body) }),
+        status,
+      };
+      return { name: 'FunctionsHttpError', context: { response: mockResponse } };
+    }
+
+    it('persists Google\'s real permission error, not the generic Supabase wrapper text, when a sync fails', async () => {
+      const service = await import('./googleCalendar.service');
+
+      mockSupabase.maybeSingle
+        .mockResolvedValueOnce({ data: mockSettings, error: null }) // settings lookup
+        .mockResolvedValueOnce({ data: null, error: null })          // no existing sync
+        .mockResolvedValueOnce({                                     // updateGigSyncStatus's own upsert result
+          data: { id: 'sync-status-1', gig_id: 'gig-123', user_id: 'user-123', sync_status: 'failed' },
+          error: null,
+        });
+
+      const functionsErr = makeFunctionsHttpError(
+        { error: 'Failed to create/update event', details: 'You need to have writer access to this calendar.' },
+        403
+      );
+      mockSupabase.functions.invoke.mockResolvedValue({ data: null, error: functionsErr });
+
+      const gigData = {
+        title: 'St. Raymond Festival',
+        start: '2026-10-03T20:00:00.000Z',
+        end: '2026-10-03T23:00:00.000Z',
+        timezone: 'America/Los_Angeles',
+      };
+
+      await expect(service.syncGigToCalendar('user-123', 'gig-123', gigData)).rejects.toThrow(
+        'You need to have writer access to this calendar.'
+      );
+
+      const failedUpsertCall = mockSupabase.upsert.mock.calls.find(
+        (call: any[]) => call[0]?.sync_status === 'failed'
+      );
+      expect(failedUpsertCall).toBeDefined();
+      expect(failedUpsertCall![0].sync_error).toBe('You need to have writer access to this calendar.');
+      expect(failedUpsertCall![0].sync_error).not.toContain('non-2xx');
+    });
+
+    it('still treats an already-deleted (404) calendar event as successfully removed after unwrapping the error', async () => {
+      const service = await import('./googleCalendar.service');
+
+      mockSupabase.maybeSingle
+        .mockResolvedValueOnce({ data: { google_event_id: 'stale-event-1' }, error: null }) // existing sync status
+        .mockResolvedValueOnce({ data: mockSettings, error: null })                          // settings lookup
+        .mockResolvedValueOnce({                                                             // updateGigSyncStatus's own upsert result
+          data: { id: 'sync-status-1', gig_id: 'gig-123', user_id: 'user-123', sync_status: 'removed' },
+          error: null,
+        });
+
+      const functionsErr = makeFunctionsHttpError(
+        { error: 'Failed to delete event', details: 'Not Found (404)' },
+        404
+      );
+      mockSupabase.functions.invoke.mockResolvedValue({ data: null, error: functionsErr });
+
+      await service.deleteGigFromCalendar('user-123', 'gig-123');
+
+      const removedUpsertCall = mockSupabase.upsert.mock.calls.find(
+        (call: any[]) => call[0]?.sync_status === 'removed'
+      );
+      expect(removedUpsertCall).toBeDefined();
+      expect(removedUpsertCall![0].sync_error).toBeNull();
+    });
+  });
+
   describe('bulkSyncAllGigsServerSide', () => {
     it('successfully queries all gigs and invokes sync-gig-all-users for each', async () => {
       const service = await import('./googleCalendar.service');

--- a/src/services/googleCalendar.service.ts
+++ b/src/services/googleCalendar.service.ts
@@ -1,7 +1,7 @@
 import { createClient } from '../utils/supabase/client';
 import type { Json } from '../utils/supabase/database.types';
 import { UserGoogleCalendarSettings, GigSyncStatus } from '../utils/supabase/types';
-import { handleApiError, handleFunctionsError } from '../utils/api-error-utils';
+import { handleApiError, handleFunctionsError, unwrapFunctionsError } from '../utils/api-error-utils';
 import { isNoonUTC } from '../utils/dateUtils';
 
 const getSupabase = () => createClient();
@@ -356,7 +356,15 @@ export async function deleteGigFromCalendar(userId: string, gigId: string): Prom
       sync_error: null,
     });
   } catch (error) {
-    if (error instanceof Error && (error.message.includes('404') || error.message.includes('410'))) {
+    // Unwrap the real reason (e.g. Google's own error message) before it's
+    // persisted or branched on — the raw FunctionsHttpError's `.message` is
+    // always the generic "Edge Function returned a non-2xx status code",
+    // which would make the 404/410 check below never match and would hide
+    // the actual cause from the Sync Log.
+    const unwrapped = await unwrapFunctionsError(error);
+    const message = typeof unwrapped?.message === 'string' ? unwrapped.message : 'Unknown error';
+
+    if (message.includes('404') || message.includes('410')) {
       await updateGigSyncStatus(gigId, userId, {
         google_event_id: null,
         sync_status: 'removed',
@@ -366,10 +374,10 @@ export async function deleteGigFromCalendar(userId: string, gigId: string): Prom
     } else {
       await updateGigSyncStatus(gigId, userId, {
         sync_status: 'failed',
-        sync_error: error instanceof Error ? error.message : 'Unknown error',
+        sync_error: message,
         last_synced_at: new Date().toISOString(),
       });
-      throw await handleFunctionsError(error, 'delete gig from calendar');
+      return handleApiError(unwrapped, 'delete gig from calendar');
     }
   }
 }
@@ -664,12 +672,20 @@ async function syncGigToCalendarWithToken(
 
     return { eventId, syncedAt: new Date() };
   } catch (error) {
+    // Unwrap before persisting, not after — otherwise every failure gets
+    // saved with Supabase's generic "Edge Function returned a non-2xx status
+    // code" instead of the real reason (e.g. Google's own error message),
+    // which is exactly what made every row in the Sync Log look identical
+    // during the issue #9 outage.
+    const unwrapped = await unwrapFunctionsError(error);
+    const message = typeof unwrapped?.message === 'string' ? unwrapped.message : 'Unknown error';
+
     await updateGigSyncStatus(gigId, userId, {
       sync_status: 'failed',
-      sync_error: error instanceof Error ? error.message : 'Unknown error',
+      sync_error: message,
       last_synced_at: new Date().toISOString(),
     });
-    throw await handleFunctionsError(error, 'sync gig to calendar');
+    return handleApiError(unwrapped, 'sync gig to calendar');
   }
 }
 

--- a/src/utils/api-error-utils.test.ts
+++ b/src/utils/api-error-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isNetworkError, handleApiError, handleFunctionsError } from './api-error-utils';
+import { isNetworkError, handleApiError, handleFunctionsError, unwrapFunctionsError } from './api-error-utils';
 
 describe('isNetworkError', () => {
   it('detects "Failed to fetch" message', () => {
@@ -75,7 +75,15 @@ describe('handleFunctionsError', () => {
     await expect(handleFunctionsError(err, 'call function')).rejects.toThrow('Generic error');
   });
 
-  it('parses error message from a FunctionsHttpError with a JSON body (via context.response)', async () => {
+  it('prefers the specific "details" field over the generic "error" label from a FunctionsHttpError body', async () => {
+    // Edge function routes in this app consistently return a generic `error`
+    // label plus a specific `details` (e.g. Google's own error message) —
+    // `details` must win so the user sees the actionable reason, not the
+    // generic route-level label. This is what made the Google Calendar sync
+    // failures in issue #9 undiagnosable from the UI: every failure showed
+    // "Failed to create/update event" (or worse, Supabase's own generic
+    // "Edge Function returned a non-2xx status code") instead of Google's
+    // real reason ("You need to have writer access to this calendar.").
     const body = { error: 'Permission denied', details: 'insufficient role' };
     const mockResponse = {
       // The code checks `typeof response.json === 'function'` before calling clone().json()
@@ -95,8 +103,28 @@ describe('handleFunctionsError', () => {
       caught = e;
     }
     expect(caught).toBeDefined();
-    expect(caught!.message).toBe('Permission denied');
+    expect(caught!.message).toBe('insufficient role');
     expect((caught as any).status).toBe(403);
+  });
+
+  it('surfaces the real Google Calendar permission error instead of a generic label (issue #9 regression)', async () => {
+    const body = {
+      error: 'Failed to create/update event',
+      details: 'You need to have writer access to this calendar.',
+    };
+    const mockResponse = {
+      json: () => Promise.resolve(body),
+      clone: () => ({ json: () => Promise.resolve(body) }),
+      status: 403,
+    };
+    const functionsErr = {
+      name: 'FunctionsHttpError',
+      context: { response: mockResponse },
+    };
+
+    await expect(handleFunctionsError(functionsErr, 'sync gig to calendar')).rejects.toThrow(
+      'You need to have writer access to this calendar.'
+    );
   });
 
   it('parses "message" field when "error" field is absent', async () => {
@@ -137,5 +165,45 @@ describe('handleFunctionsError', () => {
     };
 
     await expect(handleFunctionsError(functionsErr, 'call edge fn')).rejects.toBeDefined();
+  });
+});
+
+describe('unwrapFunctionsError', () => {
+  it('returns the original error unchanged instead of throwing', async () => {
+    const err = new Error('Generic error');
+    const result = await unwrapFunctionsError(err);
+    expect(result).toBe(err);
+  });
+
+  it('unwraps a FunctionsHttpError body into an Error carrying the real message', async () => {
+    const body = { error: 'Failed to create/update event', details: 'Forbidden' };
+    const mockResponse = {
+      json: () => Promise.resolve(body),
+      clone: () => ({ json: () => Promise.resolve(body) }),
+      status: 403,
+    };
+    const functionsErr = {
+      name: 'FunctionsHttpError',
+      context: { response: mockResponse },
+    };
+
+    const result = await unwrapFunctionsError(functionsErr);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('Forbidden');
+    expect(result.status).toBe(403);
+  });
+
+  it('returns the original error when the body has no error/details/message', async () => {
+    const mockResponse = {
+      clone: () => ({ json: () => Promise.resolve(null) }),
+      status: 500,
+    };
+    const functionsErr = {
+      name: 'FunctionsHttpError',
+      context: { response: mockResponse },
+    };
+
+    const result = await unwrapFunctionsError(functionsErr);
+    expect(result).toBe(functionsErr);
   });
 });

--- a/src/utils/api-error-utils.ts
+++ b/src/utils/api-error-utils.ts
@@ -31,58 +31,71 @@ export const handleApiError = (err: any, context: string) => {
 };
 
 /**
+ * Unwraps a Supabase FunctionsHttpError's response body into a proper Error
+ * with a meaningful `.message`, without throwing — the original error is
+ * returned unchanged if it isn't a FunctionsHttpError or has no parseable
+ * body. Edge function error bodies in this app consistently put the specific,
+ * actionable reason (e.g. Google's own error message) in `details`, with
+ * `error` reserved for a generic, route-level label ("Failed to create/update
+ * event") — so `details` is preferred over `error` when both are present.
+ */
+export const unwrapFunctionsError = async (error: any): Promise<any> => {
+  if (!(error && error.name === 'FunctionsHttpError' && error.context)) {
+    return error;
+  }
+
+  try {
+    // In some versions context is the Response, in others it's an object containing it
+    // Be resilient: check if context itself looks like a Response
+    let response = null;
+    if (error.context instanceof Response || (error.context && typeof error.context.clone === 'function')) {
+      response = error.context;
+    } else if (error.context?.response) {
+      response = error.context.response;
+    }
+
+    if (!response) return error;
+
+    let body;
+    if (typeof response.json === 'function') {
+      // Use clone() to avoid draining the stream
+      const cloned = response.clone();
+      try {
+        body = await cloned.json();
+      } catch (e) {
+        body = await cloned.text().catch(() => null);
+      }
+    }
+
+    if (!body) return error;
+
+    const errorMessage = typeof body === 'string'
+      ? body
+      : (body.details || body.error || body.message || 'Unknown function error');
+
+    const customError: any = new Error(errorMessage);
+    customError.status = response.status;
+
+    if (typeof body === 'object') {
+      customError.details = body.details || body.error;
+      customError.hint = body.hint;
+      customError.code = body.code;
+      customError.error_description = body.error_description;
+    }
+
+    return customError;
+  } catch (e) {
+    console.error('Error parsing functions error body:', e);
+    return error;
+  }
+};
+
+/**
  * Specifically handle errors from Supabase Functions
  * Attempts to parse the error message from the response body
  */
 export const handleFunctionsError = async (error: any, context: string) => {
-  if (error && error.name === 'FunctionsHttpError' && error.context) {
-    let customError: any = null;
-    try {
-      // In some versions context is the Response, in others it's an object containing it
-      // Be resilient: check if context itself looks like a Response
-      let response = null;
-      if (error.context instanceof Response || (error.context && typeof error.context.clone === 'function')) {
-        response = error.context;
-      } else if (error.context?.response) {
-        response = error.context.response;
-      }
-      
-      if (response) {
-        let body;
-        if (typeof response.json === 'function') {
-          // Use clone() to avoid draining the stream
-          const cloned = response.clone();
-          try {
-            body = await cloned.json();
-          } catch (e) {
-            body = await cloned.text().catch(() => null);
-          }
-        }
-
-        if (body) {
-          const errorMessage = typeof body === 'string' 
-            ? body 
-            : (body.error || body.message || 'Unknown function error');
-          
-          customError = new Error(errorMessage);
-          customError.status = response.status;
-          
-          if (typeof body === 'object') {
-            customError.details = body.details || body.error;
-            customError.hint = body.hint;
-            customError.code = body.code;
-            customError.error_description = body.error_description;
-          }
-        }
-      }
-    } catch (e) {
-      console.error('Error parsing functions error body:', e);
-    }
-
-    if (customError) {
-      return handleApiError(customError, context);
-    }
-  }
-  return handleApiError(error, context);
+  const unwrapped = await unwrapFunctionsError(error);
+  return handleApiError(unwrapped, context);
 };
 

--- a/supabase/functions/server/routes/calendar.ts
+++ b/supabase/functions/server/routes/calendar.ts
@@ -90,7 +90,10 @@ export function registerCalendar(app: App) {
     const eventResult = await eventResponse.json();
     if (!eventResponse.ok) {
       console.error('Google Calendar event error:', eventResult);
-      return c.json({ error: 'Failed to create/update event', details: eventResult.error?.message }, eventResponse.status as any);
+      const details = eventResponse.status === 403
+        ? `You don't have permission to write to this Google Calendar. Ask the calendar owner to share it with "Make changes to events" access, or connect using an account that owns it. (${eventResult.error?.message || 'Forbidden'})`
+        : eventResult.error?.message;
+      return c.json({ error: 'Failed to create/update event', details }, eventResponse.status as any);
     }
     return c.json({ event_id: eventResult.id });
   });
@@ -105,7 +108,10 @@ export function registerCalendar(app: App) {
     if (!deleteResponse.ok && deleteResponse.status !== 410) {
       const errorData = await deleteResponse.json().catch(() => ({}));
       console.error('Google Calendar delete error:', errorData);
-      return c.json({ error: 'Failed to delete event', details: (errorData as any).error?.message }, deleteResponse.status as any);
+      const details = deleteResponse.status === 403
+        ? `You don't have permission to modify this Google Calendar. Ask the calendar owner to share it with "Make changes to events" access, or connect using an account that owns it. (${(errorData as any).error?.message || 'Forbidden'})`
+        : (errorData as any).error?.message;
+      return c.json({ error: 'Failed to delete event', details }, deleteResponse.status as any);
     }
     return c.json({ success: true });
   });


### PR DESCRIPTION
## Summary

Closes #9. Root cause: the account connected to GigWrangler had only **read** access to the selected Google Calendar ("Act4Audio"), so every write from "Sync all Gigs" was rejected by Google with a `403 Forbidden` / `"You need to have writer access to this calendar."` — confirmed from Cameron's Supabase Edge Function logs. Reconnecting as the calendar's owner fixed the immediate case; this PR fixes the diagnosability and prevention around it so it isn't silent next time.

### Bug 1 — the real error was discarded before it reached the UI

`googleCalendar.service.ts`'s two sync catch blocks (`syncGigToCalendarWithToken`, `deleteGigFromCalendar`) persisted `sync_error` from the raw thrown error's `.message` — but Supabase's client library hardcodes that to `"Edge Function returned a non-2xx status code"` for any non-2xx edge function response. The real reason only lives in the error's `.context` (the response body), which `handleFunctionsError` already knew how to unwrap — just too late, after the generic text was already saved. This is exactly why every failed row in the Sync Log showed identical boilerplate regardless of the actual cause.

- `api-error-utils.ts`: extracted the unwrapping logic into a new `unwrapFunctionsError` (non-throwing, reusable) that `handleFunctionsError` now delegates to. Also fixed the field precedence: edge function error bodies in this app consistently put the specific, actionable reason in `details` with `error` reserved for a generic route-level label — the unwrap logic was preferring `error` over `details`, so even after fixing the ordering bug you'd have seen "Failed to create/update event" instead of Google's real "You need to have writer access to this calendar."
- `googleCalendar.service.ts`: both catch blocks now unwrap first, then persist the real message.

### Bug 2 — no prevention, just a wall of identical failures

`CalendarIntegrationSettings.tsx`:
- The calendar picker now only offers calendars where Google reports `accessRole` as `writer` or `owner` — a read-only calendar can no longer be selected in the first place.
- If a previously-selected calendar's access is later downgraded, a warning banner explains why and "Sync All Gigs" is disabled until it's resolved (instead of running a 90-event batch that's doomed to fail).

### Edge function — friendlier 403s

`supabase/functions/server/routes/calendar.ts`: the `/events` POST/DELETE routes now turn a 403 into a specific, actionable message ("...Ask the calendar owner to share it with 'Make changes to events' access...") instead of just passing through Google's bare "Forbidden".

### Documentation

This requirement (OAuth scope vs. per-calendar sharing role are independent, and a user can be "Connected" while only holding read access) wasn't written down anywhere. Added:
- `docs/technical/setup-guide.md`: a support-facing note on diagnosing/fixing this for a given user.
- `docs/development/user-documentation-plan.md`: a note in the planned end-user Calendar & Integrations section.

### Test plan

- [x] `api-error-utils.test.ts`: new tests for `unwrapFunctionsError`, and a regression test proving the `details`-over-`error` precedence fix (updated one pre-existing test that had locked in the old, buggy precedence).
- [x] `googleCalendar.service.test.ts`: regression tests confirming `sync_error` gets Google's real permission message (not generic text) on sync failure, and that the 404/410 "already removed" fallback correctly fires post-unwrap.
- [x] `CalendarIntegrationSettings.test.tsx`: new tests for the read-only-calendar warning banner and the disabled "Sync All Gigs" button.
- [x] Full suite: `npx vitest run` — 779/779 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.
- [ ] The edge function change (`calendar.ts`) isn't covered by an automated test — no Deno test harness exists for this route file in the repo, and mocking Google's API at that layer wasn't proportionate to a two-branch string change. Worth a quick manual sanity check after deploy: trigger a 403 (e.g. select a read-only calendar via direct DB edit) and confirm the friendlier message appears in the Sync Log.
- [ ] Manual click-through of the settings UI not performed in this sandbox (no way to run the dev server against a real Supabase instance here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126SEcf4GHPNLWmE5bCsgeL

---
_Generated by [Claude Code](https://claude.ai/code/session_0126SEcf4GHPNLWmE5bCsgeL)_