### PR TITLE
Fix mobile save error for single-day all-day gigs

### DIFF
--- a/src/components/mobile/MobileGigDetail.test.tsx
+++ b/src/components/mobile/MobileGigDetail.test.tsx
@@ -404,6 +404,42 @@ describe('MobileGigDetail', () => {
       expect(screen.getByText('Cancel')).toBeInTheDocument()
     })
 
+    it('saves a single-day all-day gig without the end<=start error (regression for #10)', async () => {
+      vi.mocked(getGig).mockResolvedValue({
+        ...mockGig,
+        start: '2026-07-15T12:00:00.000Z',
+        end: '2026-07-15T12:00:00.000Z',
+      } as unknown as Awaited<ReturnType<typeof getGig>>)
+      mockUseAuth.mockReturnValue({
+        user: { id: 'user-1' },
+        userRole: 'Admin',
+        selectedOrganization: { id: 'org-1' },
+      })
+      render(<MobileGigDetail gigId="gig-1" onBack={vi.fn()} onViewPackingList={vi.fn()} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Summer Festival')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /edit gig/i }))
+
+      await waitFor(() => {
+        expect(screen.getByText('Save')).toBeInTheDocument()
+      })
+
+      await act(async () => {
+        fireEvent.click(screen.getByText('Save'))
+      })
+
+      await waitFor(() => {
+        expect(updateGig).toHaveBeenCalledWith('gig-1', expect.objectContaining({
+          title: 'Summer Festival',
+        }))
+      })
+
+      expect(toast.error).not.toHaveBeenCalledWith('End date/time must be after start date/time')
+    })
+
     it('participant X button removes participant from edit list', async () => {
       mockUseAuth.mockReturnValue({
         user: { id: 'user-1' },

--- a/src/components/mobile/MobileGigDetail.tsx
+++ b/src/components/mobile/MobileGigDetail.tsx
@@ -199,7 +199,7 @@ export default function MobileGigDetail({ gigId, onBack, onViewPackingList }: Mo
           : undefined;
       }
 
-      if (end && new Date(end) <= new Date(start)) {
+      if (!editAllDay && end && new Date(end) <= new Date(start)) {
         toast.error('End date/time must be after start date/time');
         setIsSaving(false);
         return;


### PR DESCRIPTION
## Summary

Closes #10. `MobileGigDetail.tsx`'s save validation never exempted all-day gigs from the `end <= start` guard, while the equivalent web code (`GigBasicInfoSection.tsx`) already does. All-day dates are encoded as noon-UTC sentinel timestamps; for a single-day all-day gig, `start` and `end` resolve to the *identical* timestamp, so `new Date(end) <= new Date(start)` was always `true` and blocked saving with "End date/time must be after start date/time". Multi-day all-day edits were unaffected since they land on different calendar dates.

## Fix

One-line exemption in `MobileGigDetail.tsx`'s `handleSave`, mirroring the web behavior:

```diff
- if (end && new Date(end) <= new Date(start)) {
+ if (!editAllDay && end && new Date(end) <= new Date(start)) {
```

## Test plan

- [x] Added a regression test (`MobileGigDetail.test.tsx`) reproducing the bug: editing/saving a single-day all-day gig — confirmed it failed against the pre-fix code.
- [x] Applied the fix, confirmed the new test passes.
- [x] Full suite: `npx vitest run` — 772/772 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean (one pre-existing, unrelated `react-hooks/exhaustive-deps` warning).

No DB migration involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VHiNVTvfCaXBDWWW4s3gf

---
_Generated by [Claude Code](https://claude.ai/code/session_017VHiNVTvfCaXBDWWW4s3gf)_