### PR TITLE
Fix expense/financial dates and mileage rate year off-by-one

### DIFF
--- a/src/components/gig/GigFinancialsSection.test.tsx
+++ b/src/components/gig/GigFinancialsSection.test.tsx
@@ -151,6 +151,28 @@ describe('GigFinancialsSection', () => {
     expect(screen.getByText('Camera rental')).toBeInTheDocument();
   });
 
+  it('displays the stored calendar date, not a day earlier, in timezones behind UTC', async () => {
+    // Regression test for #25: a date-only value like "2024-01-15" was being
+    // parsed as UTC midnight and then rendered in the browser's local
+    // timezone, rolling the display back a day west of UTC.
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    try {
+      render(<GigFinancialsSection {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Financials')).toBeInTheDocument();
+      });
+
+      expect(screen.getAllByText('Jan 15, 2024').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Jan 20, 2024').length).toBeGreaterThan(0);
+      expect(screen.queryByText('Jan 14, 2024')).not.toBeInTheDocument();
+      expect(screen.queryByText('Jan 19, 2024')).not.toBeInTheDocument();
+    } finally {
+      process.env.TZ = originalTZ;
+    }
+  });
+
   it('shows empty state when no financials exist', async () => {
     vi.mocked(gigService.getGigFinancials).mockResolvedValue([]);
     vi.mocked(gigService.getGigProfitabilitySummary).mockResolvedValue({

--- a/src/components/gig/GigFinancialsSection.tsx
+++ b/src/components/gig/GigFinancialsSection.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import {useForm, useFieldArray } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { toast } from 'sonner';
 import {DollarSign, FileText, Loader2, Trash2, Edit, ExternalLink, Paperclip } from 'lucide-react';
 import { Button } from '../ui/button';
@@ -486,7 +486,10 @@ export default function GigFinancialsSection({
   const formatDate = (dateStr: string) => {
     if (!dateStr) return '';
     try {
-      return format(new Date(dateStr), 'MMM dd, yyyy');
+      // dateStr is a plain date-only string (e.g. "2026-09-06"); parseISO treats
+      // it as local midnight, unlike `new Date()` which treats it as UTC and can
+      // roll the display back a day in timezones behind UTC.
+      return format(parseISO(dateStr), 'MMM dd, yyyy');
     } catch {
       return dateStr;
     }

--- a/src/components/gig/QuickActionButtons.test.tsx
+++ b/src/components/gig/QuickActionButtons.test.tsx
@@ -89,6 +89,42 @@ describe('QuickActionButtons', () => {
     });
   });
 
+  it('uses the mileage rate for the entered calendar year, not a day earlier in timezones behind UTC', async () => {
+    // Regression test for #25: the mileage rate year was computed with
+    // `new Date(dateOnlyString).getFullYear()`, which parses the date as
+    // UTC midnight. West of UTC that rolls the date (and year, at a
+    // year boundary) back by one day, picking the wrong IRS rate.
+    const originalTZ = process.env.TZ;
+    process.env.TZ = 'America/Los_Angeles';
+    try {
+      render(<QuickActionButtons {...defaultProps} gigStartDate="2025-01-01" />);
+
+      fireEvent.click(screen.getByText('Expense / Mileage'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Mileage', { selector: 'div.font-semibold' })).toBeInTheDocument();
+      });
+      fireEvent.click(screen.getByText('Mileage', { selector: 'div.font-semibold' }));
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Miles Driven/)).toBeInTheDocument();
+      });
+      fireEvent.change(screen.getByLabelText(/Miles Driven/), { target: { value: '100' } });
+      fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Test travel' } });
+
+      fireEvent.click(screen.getByText('Save Mileage'));
+
+      await waitFor(() => {
+        expect(gigService.createGigFinancial).toHaveBeenCalledWith(expect.objectContaining({
+          mileage: 100,
+          amount: 67.5, // 2025 rate (0.675/mi). The pre-fix bug computed year 2024 (0.67/mi -> 67).
+        }));
+      });
+    } finally {
+      process.env.TZ = originalTZ;
+    }
+  });
+
   it('calculates mileage correctly from odometer readings', async () => {
     render(<QuickActionButtons {...defaultProps} />);
     

--- a/src/components/gig/QuickActionButtons.tsx
+++ b/src/components/gig/QuickActionButtons.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import { toast } from 'sonner';
 import { 
   FileText, 
@@ -145,7 +145,7 @@ export default function QuickActionButtons({
     return 0;
   })();
 
-  const computedYear = milDate ? new Date(milDate).getFullYear() : new Date().getFullYear();
+  const computedYear = milDate ? parseISO(milDate).getFullYear() : new Date().getFullYear();
   const computedRate = getMileageRateForYear(computedYear);
   const computedAmount = computedDistance > 0 ? calculateMileageAmount(computedDistance, computedYear) : 0;
 
@@ -227,7 +227,7 @@ export default function QuickActionButtons({
         return;
       }
 
-      const year = new Date(data.date).getFullYear();
+      const year = parseISO(data.date).getFullYear();
       const amount = calculateMileageAmount(distance, year);
       const rate = getMileageRateForYear(year);
       const autoNotes = formatMileageNotes(distance, rate);


### PR DESCRIPTION
## Summary
- Fixes #25: expense/payment/agreement dates displayed one day earlier than entered in timezones behind UTC.
- `GigFinancialsSection.tsx`'s `formatDate()` parsed the date-only DB value (e.g. `"2026-09-06"`) with `new Date(dateStr)`, which treats it as UTC midnight; formatting that in the browser's local timezone rolled the display back a day west of UTC. Switched to date-fns `parseISO`, which parses date-only strings as local midnight — the same pattern already used in `MobileGigFinancials.tsx`.
- Same root cause also affected `QuickActionButtons.tsx`'s mileage-rate year computation (`new Date(data.date).getFullYear()`, two call sites), which could pick the wrong IRS mileage rate at a year boundary. Same fix applied there.

## Test plan
- [x] New regression test in `GigFinancialsSection.test.tsx` asserting a `2024-01-15` record displays as "Jan 15, 2024" (not "Jan 14, 2024") under `TZ=America/Los_Angeles`.
- [x] New regression test in `QuickActionButtons.test.tsx` asserting mileage entered for `2025-01-01` under `TZ=America/Los_Angeles` uses the 2025 rate (0.675/mi → 67.5), not the 2024 rate (0.67/mi → 67) that the bug produced.
- [x] Confirmed both new tests fail on the pre-fix code and pass after the fix.
- [x] `npx vitest run` on both affected test files — 27/27 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCwGsLHe1bxWd1tj3zKZb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCwGsLHe1bxWd1tj3zKZb1)_