### PR TITLE
Fix new gig-edit rows not fully rendering until reload

### DIFF
--- a/src/components/gig/GigParticipantsSection.test.tsx
+++ b/src/components/gig/GigParticipantsSection.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GigParticipantsSection from './GigParticipantsSection';
 
@@ -32,6 +32,26 @@ vi.mock('../../services/gig.service', () => ({
 
 vi.mock('../../services/organization.service', () => ({
   getOrganizationContacts: vi.fn().mockResolvedValue([]),
+}));
+
+// The real OrganizationSelector debounces a network search; stub it with a
+// single button that reports a fixed pick, so tests can select an
+// organization for a newly-added row deterministically and synchronously.
+// Once a selection is made (selectedOrganization is set), just show its name,
+// mirroring the real component's compact "selected" display closely enough
+// for assertions that look for the organization name on screen.
+vi.mock('../OrganizationSelector', () => ({
+  default: ({ onSelect, selectedOrganization }: { onSelect: (org: any) => void; selectedOrganization: any }) =>
+    selectedOrganization ? (
+      <span>{selectedOrganization.name}</span>
+    ) : (
+      <button
+        type="button"
+        onClick={() => onSelect({ id: 'org-2', name: 'New Org', roles: ['Production'] })}
+      >
+        Mock Select Org
+      </button>
+    ),
 }));
 
 describe('GigParticipantsSection', () => {
@@ -75,9 +95,33 @@ describe('GigParticipantsSection', () => {
 
   it('does not render manual save button', async () => {
     render(<GigParticipantsSection {...mockProps} />);
-    
+
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows the "More actions" menu for a newly added participant without reloading (regression for #28)', async () => {
+    render(<GigParticipantsSection {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Org')).toBeInTheDocument();
+    });
+
+    const before = screen.getAllByTitle('More actions').length;
+
+    fireEvent.click(screen.getByText('Add Participant'));
+
+    // The newly added row renders the (mocked) OrganizationSelector until an
+    // organization is picked for it.
+    fireEvent.click(await screen.findByText('Mock Select Org'));
+
+    // Picking an organization goes through setValue(), which the fields[]
+    // snapshot from useFieldArray does not pick up — only the reactive
+    // watch()-derived form values do. The "More actions" menu (and the
+    // contact list behind it) should appear right away, not after a reload.
+    await waitFor(() => {
+      expect(screen.getAllByTitle('More actions')).toHaveLength(before + 1);
     });
   });
 });

--- a/src/components/gig/GigParticipantsSection.tsx
+++ b/src/components/gig/GigParticipantsSection.tsx
@@ -286,7 +286,16 @@ export default function GigParticipantsSection({
       </CardHeader>
       <CardContent>
         <div className="divide-y divide-gray-100">
-          {fields.map((field, index) => (
+          {fields.map((field, index) => {
+            // useFieldArray's `fields` snapshot only updates on append/remove/
+            // etc. — it does NOT pick up plain setValue() calls, which is how
+            // OrganizationSelector reports a pick (see below). Read the
+            // organization fields from the live, reactive `formValues` (from
+            // watch()) instead, so a freshly-picked organization's "More
+            // actions" menu and contact list render immediately instead of
+            // only after a reload/reset().
+            const participant = formValues.participants?.[index] ?? field;
+            return (
             <div key={field.id} className="py-2 first:pt-0 last:pb-0">
               <div className="flex items-center gap-2">
                 <Controller
@@ -374,7 +383,7 @@ export default function GigParticipantsSection({
                   )}
                 />
 
-                {field.organization && (
+                {participant.organization && (
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button type="button" variant="ghost" size="sm" className="h-8 w-8 p-0 shrink-0" title="More actions">
@@ -390,12 +399,12 @@ export default function GigParticipantsSection({
                         <FileText className="w-4 h-4 mr-2" />
                         Notes
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => setViewingParticipant({ organization: field.organization as Organization, notes: watch(`participants.${index}.notes`) || '' })}>
+                      <DropdownMenuItem onClick={() => setViewingParticipant({ organization: participant.organization as Organization, notes: watch(`participants.${index}.notes`) || '' })}>
                         <Eye className="w-4 h-4 mr-2" />
                         View Organization
                       </DropdownMenuItem>
                       {isUserAdmin && onEditOrganization && (
-                        <DropdownMenuItem onClick={() => onEditOrganization!(field.organization as Organization)}>
+                        <DropdownMenuItem onClick={() => onEditOrganization!(participant.organization as Organization)}>
                           <Pencil className="w-4 h-4 mr-2" />
                           Edit Organization
                         </DropdownMenuItem>
@@ -429,17 +438,18 @@ export default function GigParticipantsSection({
                 </p>
               )}
 
-              {field.organization_id && (
+              {participant.organization_id && (
                 <GigParticipantContactsList
                   gigId={gigId}
-                  organizationId={field.organization_id}
-                  organizationName={field.organization_name || 'this organization'}
+                  organizationId={participant.organization_id}
+                  organizationName={participant.organization_name || 'this organization'}
                   addDialogOpen={addContactForIndex === index}
                   onAddDialogOpenChange={(open) => setAddContactForIndex(open ? index : null)}
                 />
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       </CardContent>
     </Card>

--- a/src/components/gig/GigStaffSlotsSection.test.tsx
+++ b/src/components/gig/GigStaffSlotsSection.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { render as rtlRender, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import GigStaffSlotsSection from './GigStaffSlotsSection';
 
@@ -90,9 +90,30 @@ describe('GigStaffSlotsSection', () => {
 
   it('does not render manual save button', async () => {
     render(<GigStaffSlotsSection {...mockProps} />);
-    
+
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows an assignment row for a newly added staff slot without reloading (regression for #16)', async () => {
+    render(<GigStaffSlotsSection {...mockProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add Staff Slot')).toBeInTheDocument();
+    });
+
+    // The pre-existing slot from getGig() has one assignment, giving one
+    // "Search for user..." field already on screen.
+    const before = screen.getAllByPlaceholderText('Search for user...').length;
+
+    fireEvent.click(screen.getByText('Add Staff Slot'));
+
+    // A freshly-added slot defaults to Required: 1, so it should render
+    // exactly one more assignment row right away — not zero, only fixed by
+    // bumping Required or reloading.
+    await waitFor(() => {
+      expect(screen.getAllByPlaceholderText('Search for user...')).toHaveLength(before + 1);
     });
   });
 });

--- a/src/components/gig/GigStaffSlotsSection.tsx
+++ b/src/components/gig/GigStaffSlotsSection.tsx
@@ -286,7 +286,23 @@ export default function GigStaffSlotsSection({
       role: '',
       count: 1,
       notes: '',
-      assignments: [],
+      // Pad with one 'Open' assignment row to match count: 1, matching the
+      // padding loadStaffSlotsData applies on load — otherwise the slot's
+      // assignment row doesn't render until count is bumped or the page
+      // is reloaded.
+      assignments: [
+        {
+          id: `temp-${Math.random().toString(36).substr(2, 9)}`,
+          user_id: '',
+          user_name: '',
+          status: 'Open',
+          compensation_type: 'rate',
+          amount: '',
+          notes: '',
+          completed_at: null,
+          units_completed: null,
+        },
+      ],
     });
   };
 


### PR DESCRIPTION
## Summary
- Fixes #16: adding a new staff slot in Gig Edit didn't show its assignment row until you bumped "Required" or reloaded the page. `handleAddStaffSlot` appended the new slot with `assignments: []`; the assignment rows render from the slot's `assignments` array, so an empty array meant nothing rendered. The existing load path (`loadStaffSlotsData`) and the "Required" count-change handler both pad assignments up to `count`, which is why bumping Required "fixed" it. Now `handleAddStaffSlot` seeds one 'Open' assignment to match the default `count: 1`.
- Fixes #28: on the Participants section, a freshly-added row's "⋯" (More actions) menu and contact list didn't appear until reload. Both were gated on `field.organization` / `field.organization_id`, read from `useFieldArray`'s `fields` snapshot — which only updates on `append`/`remove`/`update`, not on plain `setValue()` calls. Picking an organization in `OrganizationSelector` updates the form via `setValue()`, so the underlying data was correct but the stale `fields[index]` snapshot never reflected it until a full `reset()` (page reload). Now those fields are read from the reactive `watch()`-derived form values instead.

Same "freshly-added row doesn't render like a reloaded one" family Cameron flagged linking these two issues, but two distinct root causes — an empty-array default in one case, a stale non-reactive snapshot in the other.

## Test plan
- [x] New regression test in `GigStaffSlotsSection.test.tsx`: adding a staff slot renders one more "Search for user..." field immediately (no reload).
- [x] New regression test in `GigParticipantsSection.test.tsx`: picking an organization for a newly-added participant (via a mocked `OrganizationSelector`) shows the "More actions" menu immediately.
- [x] Confirmed both new tests fail on the pre-fix code and pass after the fix.
- [x] Full `src/components/gig` test suite — 66/66 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on changed files — clean (pre-existing, unrelated `exhaustive-deps` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCwGsLHe1bxWd1tj3zKZb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCwGsLHe1bxWd1tj3zKZb1)_