### PR TITLE
Harden MobileGigFinancials dialog assertions against CI flakiness

### DIFF
--- a/src/components/mobile/MobileGigFinancials.test.tsx
+++ b/src/components/mobile/MobileGigFinancials.test.tsx
@@ -91,25 +91,25 @@ describe('MobileGigFinancials', () => {
     });
 
     fireEvent.click(screen.getByText(/View \d+ Transaction/));
-    
+
     await waitFor(() => {
       expect(screen.getByText(/Transactions \(1\)/)).toBeInTheDocument();
       expect(screen.getByText('Test Agreement')).toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
   });
 
   it('shows transaction detail when a transaction is clicked', async () => {
     render(<MobileGigFinancials {...defaultProps} />);
-    
+
     await waitFor(() => {
       expect(screen.getByText('Revenue')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText(/View \d+ Transaction/));
-    
+
     await waitFor(() => {
       expect(screen.getByText('Test Agreement')).toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
 
     fireEvent.click(screen.getByText('Test Agreement'));
 


### PR DESCRIPTION
## What

Bumps two `waitFor(...)` assertions in `src/components/mobile/MobileGigFinancials.test.tsx` from the default 1000ms timeout to `{ timeout: 3000 }` (plus a little trailing-whitespace cleanup).

## Why

The post-click assertions that wait for the transactions dialog to render used the default 1000ms `waitFor` timeout, which intermittently timed out in CI (originally seen on PR #14's run) even though the same test is deterministic locally. 3000ms matches the timeout already used elsewhere in the suite for similar dialog-open assertions (e.g. `LocationExplorer.test.tsx`).

## Provenance

Recovered during a branch audit — this was the sole commit (`c925c76`) on the stale `claude/pr-14-ci-failure-2w8dhl` branch, which never had a PR opened. Cherry-picked cleanly onto current `main`.

## Testing

`TZ=UTC npx vitest run src/components/mobile/MobileGigFinancials.test.tsx` — 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)