### PR TITLE
Harden MobileGigFinancials dialog assertions against CI flakiness

### DIFF
--- a/src/components/mobile/MobileGigFinancials.test.tsx
+++ b/src/components/mobile/MobileGigFinancials.test.tsx
@@ -91,25 +91,25 @@ describe('MobileGigFinancials', () => {
     });
 
     fireEvent.click(screen.getByText(/View \d+ Transaction/));
-    
+
     await waitFor(() => {
       expect(screen.getByText(/Transactions \(1\)/)).toBeInTheDocument();
       expect(screen.getByText('Test Agreement')).toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
   });
 
   it('shows transaction detail when a transaction is clicked', async () => {
     render(<MobileGigFinancials {...defaultProps} />);
-    
+
     await waitFor(() => {
       expect(screen.getByText('Revenue')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByText(/View \d+ Transaction/));
-    
+
     await waitFor(() => {
       expect(screen.getByText('Test Agreement')).toBeInTheDocument();
-    });
+    }, { timeout: 3000 });
 
     fireEvent.click(screen.getByText('Test Agreement'));
 


### PR DESCRIPTION
The post-click assertions that wait for the transactions dialog to render used the default 1000ms waitFor timeout, which intermittently timed out in CI (PR #14's run) even though the same test is deterministic locally. Bump these two to 3000ms, matching the timeout already used elsewhere in the suite for similar dialog-open assertions (e.g. LocationExplorer.test.tsx).


Claude-Session: https://claude.ai/code/session_01Q1QCT5CTvvBJe7Ew2Hr7Hh