### PR TITLE
Fix gig change-history logging spurious no-op reschedule events

### DIFF
--- a/src/services/gig.service.test.ts
+++ b/src/services/gig.service.test.ts
@@ -824,6 +824,62 @@ describe('gig.service', () => {
         event_type: 'gig.notes_updated'
       }));
     });
+
+    it('does NOT log gig.rescheduled when only the title changes (start/end resubmitted as an equivalent instant)', async () => {
+      const gigId = 'gig-1';
+      // Same instants as preGig, just formatted the way the browser's
+      // Date#toISOString() would produce them, rather than Postgres' `+00:00` form.
+      const gigData = {
+        title: 'New Title',
+        start: '2026-09-20T14:00:00.000Z',
+        end: '2026-09-20T18:00:00.000Z',
+      };
+      const preGig = { id: 'gig-1', title: 'Old Title', notes: 'notes', start: '2026-09-20T14:00:00+00:00', end: '2026-09-20T18:00:00+00:00' };
+
+      (requireAuth as any).mockResolvedValue({ supabase: mockSupabase, user: { id: 'user-1' } });
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'gig_participants') return makeChain({ data: [{ organization_id: 'org-1' }], error: null });
+        if (table === 'organization_members') return makeChain({ data: [{ organization_id: 'org-1', role: 'Admin' }], error: null });
+        if (table === 'organizations') return makeChain({ data: { name: 'Acme' }, error: null });
+        if (table === 'gigs') return makeChain({ data: preGig, error: null });
+        return makeChain({ data: [], error: null });
+      });
+
+      await updateGig(gigId, gigData);
+
+      expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({ event_type: 'gig.renamed' }));
+      expect(logActivity).not.toHaveBeenCalledWith(expect.objectContaining({ event_type: 'gig.rescheduled' }));
+    });
+
+    it('still logs gig.rescheduled when start/end actually change', async () => {
+      const gigId = 'gig-1';
+      const gigData = {
+        start: '2026-09-21T14:00:00.000Z',
+        end: '2026-09-21T18:00:00.000Z',
+      };
+      const preGig = { id: 'gig-1', title: 'Old Title', notes: 'notes', start: '2026-09-20T14:00:00+00:00', end: '2026-09-20T18:00:00+00:00' };
+
+      (requireAuth as any).mockResolvedValue({ supabase: mockSupabase, user: { id: 'user-1' } });
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'gig_participants') return makeChain({ data: [{ organization_id: 'org-1' }], error: null });
+        if (table === 'organization_members') return makeChain({ data: [{ organization_id: 'org-1', role: 'Admin' }], error: null });
+        if (table === 'organizations') return makeChain({ data: { name: 'Acme' }, error: null });
+        if (table === 'gigs') return makeChain({ data: preGig, error: null });
+        return makeChain({ data: [], error: null });
+      });
+
+      await updateGig(gigId, gigData);
+
+      expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+        event_type: 'gig.rescheduled',
+        context: expect.objectContaining({
+          from: { start: preGig.start, end: preGig.end },
+          to: { start: gigData.start, end: gigData.end },
+        }),
+      }));
+    });
   });
 
   // ─── duplicateGig ───────────────────────────────────────────────────────────

--- a/src/services/gig.service.ts
+++ b/src/services/gig.service.ts
@@ -440,6 +440,20 @@ export async function createGig(gigData: any, options?: { skipActivityLog?: bool
 }
 
 /**
+ * Compares two ISO-ish datetime strings by the instant they represent rather
+ * than by raw string equality, since the same instant can round-trip through
+ * different string forms (e.g. Postgres' `+00:00` vs. JS `Date#toISOString`'s
+ * `Z`), which otherwise makes an unchanged value look like a real edit.
+ */
+function datesRepresentSameInstant(a?: string | null, b?: string | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aTime = new Date(a).getTime();
+  const bTime = new Date(b).getTime();
+  return !Number.isNaN(aTime) && !Number.isNaN(bTime) && aTime === bTime;
+}
+
+/**
  * Update gig details
  */
 export async function updateGig(gigId: string, gigData: {
@@ -545,7 +559,9 @@ export async function updateGig(gigId: string, gigData: {
       } catch (e) { console.error('Activity log failed:', e); }
     }
 
-    if ((gigData.start !== undefined || gigData.end !== undefined) && (gigData.start !== (preGig as any)?.start || gigData.end !== (preGig as any)?.end)) {
+    const startChanged = gigData.start !== undefined && !datesRepresentSameInstant(gigData.start, (preGig as any)?.start);
+    const endChanged = gigData.end !== undefined && !datesRepresentSameInstant(gigData.end, (preGig as any)?.end);
+    if (startChanged || endChanged) {
       try {
         await logActivity({ organization_id: primary_organization_id, event_type: 'gig.rescheduled', entity_type: 'gig', entity_id: gigId, gig_id: gigId, context: { ...baseCtx, from: { start: (preGig as any).start, end: (preGig as any).end }, to: { start: gigData.start ?? (preGig as any).start, end: gigData.end ?? (preGig as any).end } } });
       } catch (e) { console.error('Activity log failed:', e); }


### PR DESCRIPTION
## Summary

- Fixes #54: editing only a gig's title (or any field other than start/end) was also logging a bogus `"Rescheduled from 20 Sep 2026 14:00 to 20 Sep 2026 14:00"` history entry.
- Root cause: `updateGig` in `src/services/gig.service.ts` compared the freshly-submitted `start`/`end` strings to the pre-fetch values from Postgres using raw string equality. The gig-edit form autosaves the whole record on every field change (via `Date#toISOString()`, e.g. `...14:00:00.000Z`), while Postgres/PostgREST returns the same instant as `...14:00:00+00:00`. Same instant, different string — so the comparison always looked like a change, and the always-resubmitted start/end triggered a "rescheduled" event on every save.
- Fix: added a `datesRepresentSameInstant` helper that compares by parsed epoch time rather than raw string, and evaluates `start` and `end` independently (`startChanged || endChanged`) rather than requiring both fields to match.

## Test plan

- Added regression test: editing only the title (with start/end resubmitted as an equivalent instant in a different string format) logs `gig.renamed` but **not** `gig.rescheduled`.
- Added regression test: an actual reschedule (different instant) still logs `gig.rescheduled` with the correct `from`/`to` context — guards against overcorrecting into never logging real reschedules.
- `npx vitest run` — all 822 tests pass (83 files).
- `npx tsc --noEmit` — clean.
- `npx eslint src/services/gig.service.ts src/services/gig.service.test.ts` — clean.

Scope note: this PR only addresses #54 (spurious no-op events). The related #55 (missing history for participant/staff/financial/schedule changes) has open scope questions posted on that issue and is deferred pending Cameron's input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153rGCMYzB2N1kV4DpKjYvF

---
_Generated by [Claude Code](https://claude.ai/code/session_0153rGCMYzB2N1kV4DpKjYvF)_