### PR TITLE
Org-delete referential integrity (#53) + gig sub-entity change-history (#55)

### DIFF
--- a/docs/development/user-documentation-plan.md
+++ b/docs/development/user-documentation-plan.md
@@ -194,8 +194,14 @@ Resolved since the last revision — no longer blockers: **#9, #10, #16, #17, #1
 - **Field Inventory**: Using Mobile Inventory Mode to check gear in/out; nested-tree scan view. *(shipped)*
 - **Offline Access**: Understanding what data is available without a connection. *(offline sync still in progress — roadmap Sprint 5)*
 
-### 9. Change History & Audit Trail *(NEW — shipped 2026-06)*
-- **What's tracked**: create/edit/delete events for gigs, assets, and kits.
+### 9. Change History & Audit Trail *(NEW — shipped 2026-06; scope note added 2026-09-09, issue #55)*
+- **What's tracked**: create/edit/delete events for gigs, assets, and kits, plus **additions**
+  of a gig's participants, staff slots, financial records, and schedule entries (who added
+  it, and when). This is intentionally **add-only**, not full field-level auditing: editing
+  or removing an existing participant/staff slot/financial record/schedule entry does not
+  currently produce a history entry (participant *removal* is the one exception — it's
+  already logged). We are not a banking app — the goal is visibility into "something
+  changed, by whom, and when," not a complete ledger of every field on every sub-record.
 - **Reading history**: the in-context history panel on a record.
 - **Actor snapshotting**: why a past entry keeps the name/role the actor had at the time.
 - **Revert**: (if exposed in UI) restoring a prior state and its conflict checks.

--- a/src/services/gigFinancial.service.test.ts
+++ b/src/services/gigFinancial.service.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getGigExportAggregates } from './gigFinancial.service';
+import { getGigExportAggregates, updateGigFinancials } from './gigFinancial.service';
 import { createClient } from '../utils/supabase/client';
+import { requireAuth } from '../utils/supabase/auth-utils';
 
 vi.mock('../utils/supabase/client', () => ({
   createClient: vi.fn(),
 }));
+
+vi.mock('../utils/supabase/auth-utils', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('./activityLog.service', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { logActivity } from './activityLog.service';
 
 // Chainable Supabase query builder stub that resolves to `result` when awaited.
 function makeChain(result: { data: any; error: any }) {
@@ -120,5 +131,68 @@ describe('getGigExportAggregates', () => {
       return makeChain({ data: null, error: new Error('permission denied') });
     });
     await expect(getGigExportAggregates('org-1')).rejects.toThrow('permission denied');
+  });
+});
+
+// ─── updateGigFinancials (issue #55 — add-only history events) ────────────
+
+function makeFullChain(result: { data: any; error: any }) {
+  const chain: any = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'in', 'is', 'or', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+describe('updateGigFinancials', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = { from: vi.fn() };
+    (requireAuth as any).mockResolvedValue({
+      supabase: mockSupabase,
+      user: { id: 'user-1', email: 'jane@example.com', user_metadata: { first_name: 'Jane', last_name: 'Doe' } },
+    });
+  });
+
+  it('logs financial.added when a new record is inserted', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_financials') return makeFullChain({ data: [], error: null });
+      if (table === 'organizations') return makeFullChain({ data: { name: 'Acme' }, error: null });
+      if (table === 'gigs') return makeFullChain({ data: { title: 'Test Gig' }, error: null });
+      return makeFullChain({ data: [], error: null });
+    });
+
+    await updateGigFinancials('gig-1', 'org-1', [
+      { amount: 250, date: '2026-01-01', type: 'Expense Incurred' },
+    ]);
+
+    expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'financial.added',
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      context: expect.objectContaining({
+        gig_title: 'Test Gig',
+        actor_org_name: 'Acme',
+        financial_changes: [{ amount: 250, fin_type: 'Expense Incurred' }],
+        change_count: 1,
+      }),
+    }));
+  });
+
+  it('does NOT log when only updating an existing record', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_financials') return makeFullChain({ data: [{ id: '11111111-1111-1111-1111-111111111111' }], error: null });
+      return makeFullChain({ data: [], error: null });
+    });
+
+    await updateGigFinancials('gig-1', 'org-1', [
+      { id: '11111111-1111-1111-1111-111111111111', amount: 300, date: '2026-01-01', type: 'Payment Received' },
+    ]);
+
+    expect(logActivity).not.toHaveBeenCalled();
   });
 });

--- a/src/services/gigFinancial.service.ts
+++ b/src/services/gigFinancial.service.ts
@@ -1,9 +1,10 @@
-import { FinType, FinCategory, DbGigFinancial } from '../utils/supabase/types';
+import { FinType, FinCategory, DbGigFinancial, FinancialChange } from '../utils/supabase/types';
 import { FIN_TYPE_GROUPS } from '../utils/supabase/constants';
 import { handleApiError } from '../utils/api-error-utils';
 import { requireAuth } from '../utils/supabase/auth-utils';
 import { UUID_REGEX } from '../utils/validation-utils';
 import { getSupabase } from './gigService.shared';
+import { logActivity } from './activityLog.service';
 
 /**
  * Gig financial / bid operations (Phase 7, Step 4 — extracted from
@@ -528,6 +529,8 @@ export async function updateGigFinancials(gigId: string, organizationId: string,
       await supabase.from('gig_financials').delete().in('id', idsToDelete);
     }
 
+    const financialChanges: FinancialChange[] = [];
+
     for (const fin of financials) {
       // Strip out any non-database fields like 'counterparty' object
       const { id, counterparty, ...restFin } = fin as any;
@@ -563,8 +566,33 @@ export async function updateGigFinancials(gigId: string, organizationId: string,
       } else {
         const { error: insertErr } = await supabase.from('gig_financials').insert({ ...finData, created_by: user.id });
         if (insertErr) throw insertErr;
+        financialChanges.push({ amount: finData.amount, fin_type: finData.type });
       }
     }
+
+    if (financialChanges.length > 0) {
+      try {
+        const actor_display_name = `${(user as any).user_metadata?.first_name ?? ''} ${(user as any).user_metadata?.last_name ?? ''}`.trim() || user.email || '';
+        const { data: orgRow } = await (supabase.from('organizations') as any).select('name').eq('id', organizationId).single();
+        const { data: gigRow } = await supabase.from('gigs').select('title').eq('id', gigId).single();
+        await logActivity({
+          organization_id: organizationId,
+          event_type: 'financial.added',
+          entity_type: 'financial',
+          entity_id: gigId,
+          gig_id: gigId,
+          context: {
+            context_version: 1,
+            actor_display_name,
+            actor_org_name: (orgRow as any)?.name ?? '',
+            gig_title: (gigRow as any)?.title ?? '',
+            financial_changes: financialChanges,
+            change_count: financialChanges.length
+          }
+        });
+      } catch (e) { console.error('Activity log failed:', e); }
+    }
+
     return { success: true };
   } catch (err) {
     return handleApiError(err, 'update gig financials');

--- a/src/services/gigParticipant.service.test.ts
+++ b/src/services/gigParticipant.service.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateGigParticipants } from './gigParticipant.service';
+import { requireAuth } from '../utils/supabase/auth-utils';
+
+vi.mock('../utils/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('../utils/supabase/auth-utils', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('./activityLog.service', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { logActivity } from './activityLog.service';
+
+function makeChain(result: { data: any; error: any }) {
+  const chain: any = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'in', 'is', 'or', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+// gig_participants is queried twice with different expected shapes: a bare
+// select (array, for the existing-rows fetch) and an insert().select().single()
+// (a single inserted row, for the add path) — so it needs its own two-faced stub.
+function makeParticipantsChain() {
+  const chain: any = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'in', 'is', 'or', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue({ data: { id: 'p-1' }, error: null });
+  chain.then = (resolve: any, reject: any) => Promise.resolve({ data: [], error: null }).then(resolve, reject);
+  return chain;
+}
+
+describe('updateGigParticipants (issue #55 — logs adds even without an explicit activityCtx)', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = { from: vi.fn() };
+    (requireAuth as any).mockResolvedValue({
+      supabase: mockSupabase,
+      user: { id: 'user-1', email: 'jane@example.com', user_metadata: { first_name: 'Jane', last_name: 'Doe' } },
+    });
+  });
+
+  it('derives context and logs participant.added when called without activityCtx (e.g. GigParticipantsSection autosave)', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_participants') return makeParticipantsChain();
+      if (table === 'gigs') return makeChain({ data: { title: 'Test Gig', primary_organization_id: 'org-1' }, error: null });
+      if (table === 'organizations') return makeChain({ data: { name: 'Acme' }, error: null });
+      return makeChain({ data: [], error: null });
+    });
+
+    await updateGigParticipants('gig-1', [
+      { organization_id: 'org-2', role: 'Venue' },
+    ]);
+
+    expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'participant.added',
+      organization_id: 'org-1',
+      context: expect.objectContaining({
+        gig_title: 'Test Gig',
+        actor_org_name: 'Acme',
+        role: 'Venue',
+      }),
+    }));
+  });
+
+  it('still logs correctly when an explicit activityCtx is passed (gig.service#updateGig path)', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_participants') return makeParticipantsChain();
+      if (table === 'organizations') return makeChain({ data: { name: 'Venue Org' }, error: null });
+      return makeChain({ data: [], error: null });
+    });
+
+    await updateGigParticipants(
+      'gig-1',
+      [{ organization_id: 'org-2', role: 'Venue' }],
+      { organization_id: 'org-9', actor_display_name: 'Bob', actor_org_name: 'Bob Org', gig_title: 'Explicit Gig' }
+    );
+
+    expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'participant.added',
+      organization_id: 'org-9',
+      context: expect.objectContaining({
+        gig_title: 'Explicit Gig',
+        actor_org_name: 'Bob Org',
+      }),
+    }));
+  });
+});

--- a/src/services/gigParticipant.service.ts
+++ b/src/services/gigParticipant.service.ts
@@ -30,7 +30,7 @@ export async function updateGigParticipants(
   }
 ) {
   try {
-    const { supabase } = await requireAuth();
+    const { supabase, user } = await requireAuth();
 
     const { data: existingParticipants, error: fetchError } = await supabase
       .from('gig_participants')
@@ -39,6 +39,27 @@ export async function updateGigParticipants(
 
     if (fetchError) throw fetchError;
 
+    // Callers that own the gig-level save (gig.service#updateGig) already
+    // computed this; direct callers (e.g. GigParticipantsSection's own
+    // autosave) don't, so derive it here rather than silently skipping the
+    // activity log (issue #55 — adds via this path weren't logged at all).
+    let effectiveCtx = activityCtx;
+    if (!effectiveCtx) {
+      const { data: gigRow } = await supabase.from('gigs').select('title, primary_organization_id').eq('id', gigId).single();
+      const organization_id = (gigRow as any)?.primary_organization_id ?? null;
+      let actor_org_name = '';
+      if (organization_id) {
+        const { data: orgRow } = await (supabase.from('organizations') as any).select('name').eq('id', organization_id).single();
+        actor_org_name = (orgRow as any)?.name ?? '';
+      }
+      effectiveCtx = {
+        organization_id,
+        actor_display_name: `${(user as any).user_metadata?.first_name ?? ''} ${(user as any).user_metadata?.last_name ?? ''}`.trim() || user.email || '',
+        actor_org_name,
+        gig_title: (gigRow as any)?.title ?? '',
+      };
+    }
+
     const existingIds = (existingParticipants ?? []).map(p => p.id);
     const incomingIds = participants
       .filter(p => p.id && UUID_REGEX.test(p.id))
@@ -46,7 +67,7 @@ export async function updateGigParticipants(
 
     const idsToDelete = existingIds.filter(id => !incomingIds.includes(id));
 
-    if (idsToDelete.length > 0 && activityCtx) {
+    if (idsToDelete.length > 0) {
       const removedRows = (existingParticipants ?? []).filter(p => idsToDelete.includes(p.id));
       const orgIds = removedRows.map(r => r.organization_id).filter(Boolean);
       let orgNameMap: Map<string, string> = new Map();
@@ -57,16 +78,16 @@ export async function updateGigParticipants(
       for (const row of removedRows) {
         try {
           await logActivity({
-            organization_id: activityCtx.organization_id,
+            organization_id: effectiveCtx.organization_id,
             event_type: 'participant.removed',
             entity_type: 'participant',
             entity_id: row.id,
             gig_id: gigId,
             context: {
               context_version: 1,
-              actor_display_name: activityCtx.actor_display_name,
-              actor_org_name: activityCtx.actor_org_name,
-              gig_title: activityCtx.gig_title,
+              actor_display_name: effectiveCtx.actor_display_name,
+              actor_org_name: effectiveCtx.actor_org_name,
+              gig_title: effectiveCtx.gig_title,
               organization_name: orgNameMap.get(row.organization_id) ?? '',
               role: row.role
             }
@@ -95,20 +116,20 @@ export async function updateGigParticipants(
           .insert({ gig_id: gigId, ...participantData })
           .select('id')
           .single();
-        if (activityCtx && inserted?.id) {
+        if (inserted?.id) {
           const { data: orgRow } = await (supabase.from('organizations') as any).select('name').eq('id', participant.organization_id).single();
           try {
             await logActivity({
-              organization_id: activityCtx.organization_id,
+              organization_id: effectiveCtx.organization_id,
               event_type: 'participant.added',
               entity_type: 'participant',
               entity_id: inserted.id,
               gig_id: gigId,
               context: {
                 context_version: 1,
-                actor_display_name: activityCtx.actor_display_name,
-                actor_org_name: activityCtx.actor_org_name,
-                gig_title: activityCtx.gig_title,
+                actor_display_name: effectiveCtx.actor_display_name,
+                actor_org_name: effectiveCtx.actor_org_name,
+                gig_title: effectiveCtx.gig_title,
                 organization_name: (orgRow as any)?.name ?? '',
                 role: participant.role
               }

--- a/src/services/gigSchedule.service.test.ts
+++ b/src/services/gigSchedule.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateGigScheduleEntries } from './gigSchedule.service';
+import { requireAuth } from '../utils/supabase/auth-utils';
+
+vi.mock('../utils/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('../utils/supabase/auth-utils', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('./activityLog.service', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { logActivity } from './activityLog.service';
+
+function makeChain(result: { data: any; error: any }) {
+  const chain: any = {};
+  ['select', 'insert', 'update', 'delete', 'upsert', 'eq', 'in', 'is', 'or', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue(result);
+  chain.then = (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject);
+  return chain;
+}
+
+describe('updateGigScheduleEntries (issue #55 — add-only history events)', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = { from: vi.fn() };
+    (requireAuth as any).mockResolvedValue({
+      supabase: mockSupabase,
+      user: { id: 'user-1', email: 'jane@example.com', user_metadata: { first_name: 'Jane', last_name: 'Doe' } },
+    });
+  });
+
+  it('logs schedule_entry.added when a new entry is inserted', async () => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_schedule_entries') return makeChain({ data: [], error: null });
+      if (table === 'gigs') return makeChain({ data: { title: 'Test Gig', primary_organization_id: 'org-1' }, error: null });
+      if (table === 'organizations') return makeChain({ data: { name: 'Acme' }, error: null });
+      return makeChain({ data: [], error: null });
+    });
+
+    await updateGigScheduleEntries('gig-1', [
+      { activity_type: 'Load-in', label: null, start_time: '2026-09-20T14:00:00.000Z' } as any,
+    ]);
+
+    expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'schedule_entry.added',
+      organization_id: 'org-1',
+      gig_id: 'gig-1',
+      context: expect.objectContaining({
+        gig_title: 'Test Gig',
+        actor_org_name: 'Acme',
+        schedule_changes: [{ activity_type: 'Load-in', label: null, start_time: '2026-09-20T14:00:00.000Z' }],
+        change_count: 1,
+      }),
+    }));
+  });
+
+  it('does NOT log when only updating an existing entry', async () => {
+    const existingId = '11111111-1111-1111-1111-111111111111';
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_schedule_entries') return makeChain({ data: [{ id: existingId }], error: null });
+      return makeChain({ data: [], error: null });
+    });
+
+    await updateGigScheduleEntries('gig-1', [
+      { id: existingId, activity_type: 'Load-in', start_time: '2026-09-20T14:00:00.000Z' } as any,
+    ]);
+
+    expect(logActivity).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/gigSchedule.service.ts
+++ b/src/services/gigSchedule.service.ts
@@ -1,7 +1,8 @@
 import { handleApiError } from '../utils/api-error-utils';
 import { requireAuth } from '../utils/supabase/auth-utils';
 import { getSupabase } from './gigService.shared';
-import type { GigScheduleEntry } from '../utils/supabase/types';
+import { logActivity } from './activityLog.service';
+import type { GigScheduleEntry, ScheduleChange } from '../utils/supabase/types';
 
 /**
  * Fetch schedule entries for a gig, with joined act participant data.
@@ -40,7 +41,7 @@ export async function updateGigScheduleEntries(
   entries: Array<Partial<GigScheduleEntry>>
 ): Promise<void> {
   try {
-    const { supabase } = await requireAuth();
+    const { supabase, user } = await requireAuth();
 
     const { data: existing } = await supabase
       .from('gig_schedule_entries')
@@ -98,6 +99,37 @@ export async function updateGigScheduleEntries(
         .from('gig_schedule_entries')
         .insert(toInsert);
       if (insertError) throw insertError;
+
+      try {
+        const scheduleChanges: ScheduleChange[] = toInsert.map(e => ({
+          activity_type: e.activity_type,
+          label: e.label,
+          start_time: e.start_time,
+        }));
+        const { data: gigRow } = await supabase.from('gigs').select('title, primary_organization_id').eq('id', gigId).single();
+        const organization_id = (gigRow as any)?.primary_organization_id ?? null;
+        let actor_org_name = '';
+        if (organization_id) {
+          const { data: orgRow } = await (supabase.from('organizations') as any).select('name').eq('id', organization_id).single();
+          actor_org_name = (orgRow as any)?.name ?? '';
+        }
+        const actor_display_name = `${(user as any).user_metadata?.first_name ?? ''} ${(user as any).user_metadata?.last_name ?? ''}`.trim() || user.email || '';
+        await logActivity({
+          organization_id,
+          event_type: 'schedule_entry.added',
+          entity_type: 'schedule_entry',
+          entity_id: gigId,
+          gig_id: gigId,
+          context: {
+            context_version: 1,
+            actor_display_name,
+            actor_org_name,
+            gig_title: (gigRow as any)?.title ?? '',
+            schedule_changes: scheduleChanges,
+            change_count: scheduleChanges.length
+          }
+        });
+      } catch (e) { console.error('Activity log failed:', e); }
     }
   } catch (err) {
     return handleApiError(err, 'update schedule entries') as never;

--- a/src/services/gigStaff.service.test.ts
+++ b/src/services/gigStaff.service.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateGigStaffSlots } from './gigStaff.service';
+import { requireAuth } from '../utils/supabase/auth-utils';
+
+vi.mock('../utils/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('../utils/supabase/auth-utils', () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock('./activityLog.service', () => ({
+  logActivity: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { logActivity } from './activityLog.service';
+
+// Generic chainable Supabase stub: `.then()` resolves the bare-select shape,
+// `.single()`/`.maybeSingle()` resolve their own (possibly different) shape —
+// several tables here are queried both ways in a single call.
+function makeChain(opts: { data?: any; singleData?: any; maybeSingleData?: any }) {
+  const chain: any = {};
+  ['select', 'insert', 'update', 'delete', 'eq', 'in', 'is', 'or', 'order', 'limit'].forEach((m) => {
+    chain[m] = vi.fn().mockReturnValue(chain);
+  });
+  chain.single = vi.fn().mockResolvedValue({ data: opts.singleData ?? null, error: null });
+  chain.maybeSingle = vi.fn().mockResolvedValue({ data: opts.maybeSingleData ?? null, error: null });
+  chain.then = (resolve: any, reject: any) => Promise.resolve({ data: opts.data ?? [], error: null }).then(resolve, reject);
+  return chain;
+}
+
+describe('updateGigStaffSlots (issue #55 — logs adds even without an explicit activityCtx)', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase = { from: vi.fn() };
+    (requireAuth as any).mockResolvedValue({
+      supabase: mockSupabase,
+      user: { id: 'user-1', email: 'jane@example.com', user_metadata: { first_name: 'Jane', last_name: 'Doe' } },
+    });
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'gig_participants') return makeChain({ data: [{ organization_id: 'org-1' }] });
+      if (table === 'organization_members') return makeChain({ data: [{ organization_id: 'org-1', role: 'Admin' }] });
+      if (table === 'gig_staff_slots') return makeChain({ data: [], singleData: { id: 'slot-1' } });
+      if (table === 'staff_roles') return makeChain({ data: [], maybeSingleData: null, singleData: { id: 'role-1' } });
+      if (table === 'organizations') return makeChain({ singleData: { name: 'Acme' } });
+      if (table === 'gigs') return makeChain({ singleData: { title: 'Test Gig' } });
+      return makeChain({ data: [] });
+    });
+  });
+
+  it('derives context and logs staffing.updated (slot_added) when called without activityCtx', async () => {
+    await updateGigStaffSlots('gig-1', [
+      { organization_id: 'org-1', role: 'FOH Engineer' },
+    ]);
+
+    expect(logActivity).toHaveBeenCalledWith(expect.objectContaining({
+      event_type: 'staffing.updated',
+      organization_id: 'org-1',
+      context: expect.objectContaining({
+        gig_title: 'Test Gig',
+        actor_org_name: 'Acme',
+        changes: [{ type: 'slot_added', role: 'FOH Engineer' }],
+        change_count: 1,
+      }),
+    }));
+  });
+
+  it('does not log when no slots actually change', async () => {
+    await updateGigStaffSlots('gig-1', []);
+    expect(logActivity).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/gigStaff.service.ts
+++ b/src/services/gigStaff.service.ts
@@ -164,19 +164,39 @@ export async function updateGigStaffSlots(
       }
     }
 
-    if (staffingChanges.length > 0 && activityCtx) {
+    if (staffingChanges.length > 0) {
       try {
+        // Callers that own the gig-level save already computed activityCtx;
+        // direct callers (e.g. GigStaffSlotsSection's own autosave) don't, so
+        // derive it here rather than silently skipping the log (issue #55).
+        let effectiveCtx = activityCtx;
+        if (!effectiveCtx) {
+          const primary_organization_id = userMemberships.find(m => m.role === 'Admin' || m.role === 'Manager')?.organization_id || userMemberships[0]?.organization_id || null;
+          let actor_org_name = '';
+          if (primary_organization_id) {
+            const { data: orgRow } = await (supabase.from('organizations') as any).select('name').eq('id', primary_organization_id).single();
+            actor_org_name = (orgRow as any)?.name ?? '';
+          }
+          const { data: gigRow } = await supabase.from('gigs').select('title').eq('id', gigId).single();
+          effectiveCtx = {
+            organization_id: primary_organization_id,
+            actor_display_name: `${(user as any).user_metadata?.first_name ?? ''} ${(user as any).user_metadata?.last_name ?? ''}`.trim() || user.email || '',
+            actor_org_name,
+            gig_title: (gigRow as any)?.title ?? '',
+          };
+        }
+
         await logActivity({
-          organization_id: activityCtx.organization_id,
+          organization_id: effectiveCtx.organization_id,
           event_type: 'staffing.updated',
           entity_type: 'staffing',
           entity_id: gigId,
           gig_id: gigId,
           context: {
             context_version: 1,
-            actor_display_name: activityCtx.actor_display_name,
-            actor_org_name: activityCtx.actor_org_name,
-            gig_title: activityCtx.gig_title,
+            actor_display_name: effectiveCtx.actor_display_name,
+            actor_org_name: effectiveCtx.actor_org_name,
+            gig_title: effectiveCtx.gig_title,
             changes: staffingChanges,
             change_count: staffingChanges.length
           }

--- a/src/utils/activityLog.events.test.ts
+++ b/src/utils/activityLog.events.test.ts
@@ -20,11 +20,13 @@ const EXPECTED_EVENT_TYPES: ActivityEventType[] = [
   'kit.updated',
   'kit.asset_added',
   'kit.asset_removed',
+  'financial.added',
+  'schedule_entry.added',
 ];
 
 describe('ACTIVITY_EVENTS', () => {
-  it('contains exactly 20 event types', () => {
-    expect(Object.keys(ACTIVITY_EVENTS)).toHaveLength(20);
+  it('contains exactly 22 event types', () => {
+    expect(Object.keys(ACTIVITY_EVENTS)).toHaveLength(22);
   });
 
   it('contains all expected event type keys', () => {
@@ -65,6 +67,41 @@ describe('ACTIVITY_EVENTS', () => {
     const cfg = ACTIVITY_EVENTS['staffing.updated'];
     const result = cfg.format({ context_version: 1, actor_display_name: '', actor_org_name: '' });
     expect(result).toBe('Staffing updated');
+  });
+
+  it('financial.added format renders each added record', () => {
+    const cfg = ACTIVITY_EVENTS['financial.added'];
+    const result = cfg.format({
+      context_version: 1,
+      actor_display_name: '',
+      actor_org_name: '',
+      financial_changes: [{ amount: 250, fin_type: 'Expense Incurred' }],
+      change_count: 1,
+    });
+    expect(result).toBe('Added Expense Incurred: $250.00');
+  });
+
+  it('financial.added format with no changes returns fallback text', () => {
+    const cfg = ACTIVITY_EVENTS['financial.added'];
+    expect(cfg.format({ context_version: 1, actor_display_name: '', actor_org_name: '' })).toBe('Financial record added');
+  });
+
+  it('schedule_entry.added format renders each added entry', () => {
+    const cfg = ACTIVITY_EVENTS['schedule_entry.added'];
+    const result = cfg.format({
+      context_version: 1,
+      actor_display_name: '',
+      actor_org_name: '',
+      schedule_changes: [{ activity_type: 'Load-in', label: null, start_time: '2026-09-20T14:00:00.000Z' }],
+      change_count: 1,
+    });
+    expect(result).toContain('Load-in at');
+    expect(result).toContain('20 Sep 2026');
+  });
+
+  it('schedule_entry.added format with no changes returns fallback text', () => {
+    const cfg = ACTIVITY_EVENTS['schedule_entry.added'];
+    expect(cfg.format({ context_version: 1, actor_display_name: '', actor_org_name: '' })).toBe('Schedule entry added');
   });
 
   it('gig.status_changed format uses from_status and to_status', () => {

--- a/src/utils/activityLog.events.ts
+++ b/src/utils/activityLog.events.ts
@@ -114,6 +114,32 @@ export const ACTIVITY_EVENTS = {
       return `Staffing updated: ${summary}`;
     },
   },
+  'financial.added': {
+    label: 'Financial Record Added',
+    entityType: 'financial',
+    calendarIndicator: false,
+    contextKeys: ['gig_title', 'financial_changes', 'change_count'],
+    format: (ctx) => {
+      if (!ctx.financial_changes?.length) return 'Financial record added';
+      const summary = ctx.financial_changes
+        .map((c) => `${c.fin_type}: $${c.amount.toFixed(2)}`)
+        .join('; ');
+      return `Added ${summary}`;
+    },
+  },
+  'schedule_entry.added': {
+    label: 'Schedule Entry Added',
+    entityType: 'schedule_entry',
+    calendarIndicator: false,
+    contextKeys: ['gig_title', 'schedule_changes', 'change_count'],
+    format: (ctx) => {
+      if (!ctx.schedule_changes?.length) return 'Schedule entry added';
+      const summary = ctx.schedule_changes
+        .map((c) => `${c.label || c.activity_type} at ${formatDate(c.start_time)}`)
+        .join('; ');
+      return `Added ${summary}`;
+    },
+  },
   'staffing.status_changed': {
     label: 'Staffing Status Changed',
     entityType: 'staffing',

--- a/src/utils/supabase/types.tsx
+++ b/src/utils/supabase/types.tsx
@@ -204,6 +204,17 @@ export interface FieldChange {
   to: unknown;
 }
 
+export interface FinancialChange {
+  amount: number;
+  fin_type: string;
+}
+
+export interface ScheduleChange {
+  activity_type: string;
+  label?: string | null;
+  start_time: string;
+}
+
 export interface ActivityLogContext {
   context_version: number;
   actor_display_name: string;
@@ -229,6 +240,8 @@ export interface ActivityLogContext {
   field_changes?: FieldChange[];
   notes_changed?: boolean;
   asset_name?: string;
+  financial_changes?: FinancialChange[];
+  schedule_changes?: ScheduleChange[];
 }
 
 export interface ActivityLogEntry extends Omit<DbActivityLog, 'context'> {

--- a/supabase/functions/server/lib/pure/authz.test.ts
+++ b/supabase/functions/server/lib/pure/authz.test.ts
@@ -7,6 +7,7 @@ import {
   emailDomainMatches,
   canDecideAccessRequest,
   shouldClaimOrgOnApproval,
+  describeOrganizationDeleteBlockers,
 } from './authz';
 
 describe('parseBearer', () => {
@@ -122,5 +123,26 @@ describe('shouldClaimOrgOnApproval (issue #33 bootstrap case)', () => {
   });
   it('does not re-claim an already-claimed org (e.g. approving a second Admin)', () => {
     expect(shouldClaimOrgOnApproval(true, 'Admin')).toBe(false);
+  });
+});
+
+describe('describeOrganizationDeleteBlockers (issue #53)', () => {
+  it('allows deletion when every reference count is zero', () => {
+    expect(describeOrganizationDeleteBlockers({ members: 0, assets: 0, kits: 0 })).toBeNull();
+  });
+  it('names every non-zero reference in one message', () => {
+    const message = describeOrganizationDeleteBlockers({ members: 2, assets: 0, kits: 5, 'gig participations': 1 });
+    expect(message).toContain('members');
+    expect(message).toContain('kits');
+    expect(message).toContain('gig participations');
+    expect(message).not.toContain('assets');
+  });
+  it('blocks on a single non-zero reference', () => {
+    expect(describeOrganizationDeleteBlockers({ 'financial records': 3 })).toBe(
+      'Cannot delete an organization that still has financial records. Remove them first.'
+    );
+  });
+  it('allows deletion when there are no references to check', () => {
+    expect(describeOrganizationDeleteBlockers({})).toBeNull();
   });
 });

--- a/supabase/functions/server/lib/pure/authz.ts
+++ b/supabase/functions/server/lib/pure/authz.ts
@@ -96,3 +96,45 @@ export function requireGigCreateOrgId(
   }
   return { ok: true, orgId };
 }
+
+/**
+ * Every table with a row that references an organization and would either
+ * cascade-delete (destroying real business data) or be silently orphaned
+ * (`gig_financials.organization_id` has no DB-level FK) if that organization
+ * were deleted. Used by the `DELETE /organizations/:id` referential-integrity
+ * guard (issue #53) — previously only `organization_members` and
+ * `gig_participants` were checked, so an org with assets, kits, financials,
+ * etc. could still be deleted out from under that data.
+ *
+ * `gig_financials.counterparty_id` is deliberately excluded: it's a `SET
+ * NULL` reference (an org can be someone else's counterparty), not one that
+ * would destroy or orphan the financial record itself.
+ */
+export const ORGANIZATION_DELETE_REFERENCES: ReadonlyArray<{ table: string; column: string; label: string }> = [
+  { table: 'organization_members', column: 'organization_id', label: 'members' },
+  { table: 'gig_participants', column: 'organization_id', label: 'gig participations' },
+  { table: 'gig_staff_slots', column: 'organization_id', label: 'gig staff slots' },
+  { table: 'gig_kit_assignments', column: 'organization_id', label: 'gig kit assignments' },
+  { table: 'gig_bids', column: 'organization_id', label: 'gig bids' },
+  { table: 'gig_financials', column: 'organization_id', label: 'financial records' },
+  { table: 'assets', column: 'organization_id', label: 'assets' },
+  { table: 'kits', column: 'organization_id', label: 'kits' },
+  { table: 'purchases', column: 'organization_id', label: 'purchases' },
+  { table: 'attachments', column: 'organization_id', label: 'attachments' },
+  { table: 'invitations', column: 'organization_id', label: 'pending invitations' },
+  { table: 'gig_participant_contacts', column: 'organization_id', label: 'participant contacts' },
+  { table: 'access_requests', column: 'organization_id', label: 'access requests' },
+];
+
+/**
+ * Turns a { label -> row count } map (one entry per
+ * `ORGANIZATION_DELETE_REFERENCES` row) into the user-facing error for a
+ * blocked organization delete, or null when nothing blocks it.
+ */
+export function describeOrganizationDeleteBlockers(counts: Record<string, number>): string | null {
+  const blockers = Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([label]) => label);
+  if (blockers.length === 0) return null;
+  return `Cannot delete an organization that still has ${blockers.join(', ')}. Remove them first.`;
+}

--- a/supabase/functions/server/routes/organizations.ts
+++ b/supabase/functions/server/routes/organizations.ts
@@ -1,7 +1,7 @@
 import type { App } from '../lib/types.ts';
 import { requireUser } from '../lib/auth.ts';
 import { requireOrgRole, verifyOrgMembership } from '../lib/orgRole.ts';
-import { emailDomainMatches } from '../lib/pure/authz.ts';
+import { emailDomainMatches, ORGANIZATION_DELETE_REFERENCES, describeOrganizationDeleteBlockers } from '../lib/pure/authz.ts';
 import { supabaseAdmin } from '../lib/supabaseAdmin.ts';
 
 const ORG_UPDATE_FIELDS = [
@@ -115,22 +115,19 @@ export function registerOrganizations(app: App) {
       return c.json({ error: 'Organization not found' }, 404);
     }
 
-    const { count: memberCount, error: memberCountError } = await supabaseAdmin
-      .from('organization_members').select('*', { count: 'exact', head: true }).eq('organization_id', orgId);
-    if (memberCountError) {
-      return c.json({ error: 'Failed to check organization members' }, 500);
+    const counts: Record<string, number> = {};
+    for (const ref of ORGANIZATION_DELETE_REFERENCES) {
+      const { count, error: countError } = await supabaseAdmin
+        .from(ref.table).select('*', { count: 'exact', head: true }).eq(ref.column, orgId);
+      if (countError) {
+        console.error(`Error checking ${ref.table} for org delete:`, countError);
+        return c.json({ error: `Failed to check ${ref.label}` }, 500);
+      }
+      counts[ref.label] = count ?? 0;
     }
-    if ((memberCount ?? 0) > 0) {
-      return c.json({ error: 'Cannot delete an organization that has members. Remove all members first.' }, 409);
-    }
-
-    const { count: participantCount, error: participantCountError } = await supabaseAdmin
-      .from('gig_participants').select('*', { count: 'exact', head: true }).eq('organization_id', orgId);
-    if (participantCountError) {
-      return c.json({ error: 'Failed to check gig participants' }, 500);
-    }
-    if ((participantCount ?? 0) > 0) {
-      return c.json({ error: 'Cannot delete an organization that is a participant in gigs. Remove it from all gigs first.' }, 409);
+    const blockerMessage = describeOrganizationDeleteBlockers(counts);
+    if (blockerMessage) {
+      return c.json({ error: blockerMessage }, 409);
     }
 
     const { error: deleteError } = await supabaseAdmin


### PR DESCRIPTION
## Summary

Two independent fixes, both scoped and confirmed with Cameron on the issues before implementation.

### #53 — Organization-delete referential-integrity check
`DELETE /organizations/:id` only checked `organization_members` and `gig_participants` before allowing a delete, so an org with assets, kits, financial records, purchases, etc. could still be deleted — orphaning or cascade-destroying that data. Extended the check to cover every table that references `organizations.id` (13 tables total), and it now reports every blocking reference in one error instead of just the first one found.

Verified the existing edit-permission gating separately (`canEditOrganization` client-side, `requireOrgRole({ allowGlobalAdminIfUnclaimed: true })` server-side, both backed by the `organizations` RLS policy) already implements exactly what Cameron confirmed as intended: an Admin of *that* org can always edit; an Admin of *any* org can edit only while it's unclaimed; no new role. That logic shipped in PR #48 before this issue was filed, so no change was needed there — only the delete check was the real gap.

### #55 — Add-only change-history for gig sub-entities
Change History only tracked core gig fields (title, schedule, status, notes); adding a participant, staff slot, financial record, or schedule entry produced no history entry at all. Added one add-only event per creation (no field-level diffing, no removal events yet — per Cameron's confirmed scope: "show that something changed, by whom, and when," not a full ledger).

Also fixed participant/staff add-logging on the direct-component save paths (`GigParticipantsSection`, `GigStaffSlotsSection`, `MobileGigDetail`) — those call `updateGigParticipants`/`updateGigStaffSlots` without an `activityCtx`, which the existing logging code silently required. This is why the 2026-09-08 dry run saw no history entry for an added participant despite that logging code already existing for the `gig.service#updateGig` path. Both functions now derive the actor/org/gig-title context themselves when the caller omits it.

Updated the §9 Change History docs (`docs/development/user-documentation-plan.md`) to state this add-only scope explicitly.

## Test plan

- New Vitest coverage: `authz.test.ts` (org-delete blocker message), `gigFinancial.service.test.ts`, `gigSchedule.service.test.ts` (new file), `gigParticipant.service.test.ts` (new file), `gigStaff.service.test.ts` (new file), `activityLog.events.test.ts` (new event formats).
- `npx vitest run` — all 838 tests pass (86 files).
- `npx tsc --noEmit` — clean.
- `npx eslint` on all touched files — clean.

Scope note: field-level diffing and removal events for these sub-entities are explicitly out of scope per Cameron's confirmation on #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153rGCMYzB2N1kV4DpKjYvF

---
_Generated by [Claude Code](https://claude.ai/code/session_0153rGCMYzB2N1kV4DpKjYvF)_