### PR TITLE
WebAuthn Sentry safety net + Packing List table cleanup

### DIFF
--- a/src/components/inventory/InventoryReports.test.tsx
+++ b/src/components/inventory/InventoryReports.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InventoryReports } from './InventoryReports';
+import type { PackingListRow } from '../../services/inventoryManagement.service';
+
+vi.mock('../../services/inventoryManagement.service', () => ({
+  getGigsForReportPicker: vi.fn().mockResolvedValue([{ id: 'gig-1', title: 'Test Gig' }]),
+  getInventoryConflictFlags: vi.fn().mockResolvedValue(new Set()),
+  getManifestReport: vi.fn().mockResolvedValue([]),
+  getMaintenanceQueueReport: vi.fn().mockResolvedValue([]),
+  getPackingListReport: vi.fn(),
+}));
+
+// Real Radix Select doesn't drive well under jsdom; stand in a plain version
+// that still round-trips a selection through onValueChange, so choosing a gig
+// actually changes PackingListTab's state (same shape as the existing
+// LocationExplorer.test.tsx select mock, extended to support selecting).
+vi.mock('../ui/select', () => {
+  let currentOnValueChange: (v: string) => void = () => {};
+  return {
+    Select: ({ children, onValueChange }: any) => {
+      currentOnValueChange = onValueChange;
+      return <div>{children}</div>;
+    },
+    SelectTrigger: ({ children, 'aria-label': ariaLabel }: any) => (
+      <button role="combobox" aria-label={ariaLabel}>{children}</button>
+    ),
+    SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+    SelectContent: ({ children }: any) => <div>{children}</div>,
+    SelectItem: ({ children, value }: any) => (
+      <div role="option" onClick={() => currentOnValueChange(value)}>{children}</div>
+    ),
+  };
+});
+
+import { getPackingListReport } from '../../services/inventoryManagement.service';
+
+const PACKING_ROWS: PackingListRow[] = [
+  {
+    kit_id: 'kit-lighting', kit_name: 'Lighting Kit', is_container: false,
+    asset_id: 'asset-par', asset_name: 'LED Par', tag_number: 'PAR-1', quantity: 4,
+    status: null, location: null, scanned_at: null, scanned_by_name: null, notes: null, has_conflict: false,
+  },
+  {
+    kit_id: 'kit-lighting', kit_name: 'Lighting Kit', is_container: false,
+    asset_id: 'asset-cable', asset_name: 'XLR Cable', tag_number: null, quantity: 3,
+    status: null, location: null, scanned_at: null, scanned_by_name: null, notes: null, has_conflict: false,
+  },
+  {
+    kit_id: 'kit-case', kit_name: 'Road Case', is_container: true,
+    asset_id: null, asset_name: null, tag_number: 'RC-1', quantity: 1,
+    status: null, location: null, scanned_at: null, scanned_by_name: null, notes: null, has_conflict: false,
+  },
+];
+
+async function renderPackingListTab() {
+  const user = userEvent.setup();
+  render(<InventoryReports organizationId="org-1" organizationName="Test Org" />);
+  await user.click(await screen.findByRole('tab', { name: 'Packing List' }));
+  await user.click(await screen.findByRole('option', { name: 'Test Gig' }));
+}
+
+describe('InventoryReports — Packing List tab', () => {
+  it('renders every kit group inside a single table, not one table per kit', async () => {
+    (getPackingListReport as any).mockResolvedValue(PACKING_ROWS);
+    await renderPackingListTab();
+
+    await waitFor(() => expect(screen.getByText('LED Par')).toBeInTheDocument());
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+  });
+
+  it('shows the component quantity for each item', async () => {
+    (getPackingListReport as any).mockResolvedValue(PACKING_ROWS);
+    await renderPackingListTab();
+
+    const parRow = (await screen.findByText('LED Par')).closest('tr')!;
+    expect(within(parRow).getByText('4')).toBeInTheDocument();
+
+    const cableRow = screen.getByText('XLR Cable').closest('tr')!;
+    expect(within(cableRow).getByText('3')).toBeInTheDocument();
+  });
+
+  it('gives a multi-item kit a divider row but skips it for a standalone container row', async () => {
+    (getPackingListReport as any).mockResolvedValue(PACKING_ROWS);
+    await renderPackingListTab();
+
+    await waitFor(() => expect(screen.getByText('LED Par')).toBeInTheDocument());
+
+    // Lighting Kit groups two rows — it gets its own divider row naming the kit.
+    expect(screen.getByText('Lighting Kit')).toBeInTheDocument();
+
+    // Road Case is a standalone container row — its name appears exactly
+    // once, inline on the item row itself, not also as a divider row.
+    expect(screen.getAllByText('Road Case')).toHaveLength(1);
+    const roadCaseRow = screen.getByText('Road Case').closest('tr')!;
+    expect(within(roadCaseRow).getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/components/inventory/InventoryReports.tsx
+++ b/src/components/inventory/InventoryReports.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Fragment, useState, useEffect, useCallback, useMemo } from 'react';
 import { format } from 'date-fns';
 import { AlertTriangle, Printer, SlidersHorizontal } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
@@ -529,31 +529,47 @@ function PackingListTab({
               <span className="text-sm text-muted-foreground">No kits assigned to this gig.</span>
             </div>
           ) : (
-            Array.from(rowsByKit.entries()).map(([kitId, kitRows]) => {
-              const kitName = kitRows[0]?.kit_name ?? '—';
-              const isContainer = kitRows[0]?.is_container ?? false;
-              const hasConflict = conflictFlags.has(kitId);
-              return (
-                <div key={kitId}>
-                  <div className="bg-muted/40 px-4 py-2 flex items-center gap-2 border-b">
-                    <span className="font-medium text-sm">{kitName}</span>
-                    <KitTypeBadge isContainer={isContainer} />
-                    {hasConflict && <ConflictBadge />}
-                  </div>
-                  <Table className="[&_th]:border [&_td]:border">
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-8 text-center">✓</TableHead>
-                        <TableHead>Name</TableHead>
-                        <TableHead>Tag #</TableHead>
-                        {show('status') && <TableHead>Status</TableHead>}
-                        {show('scanned_at') && <TableHead>Last Scanned</TableHead>}
-                        {show('location') && <TableHead>Location</TableHead>}
-                        {show('scanned_by') && <TableHead>Scanned By</TableHead>}
-                        {show('notes') && <TableHead>Notes</TableHead>}
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
+            <Table className="[&_th]:border [&_td]:border">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8 text-center">✓</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Tag #</TableHead>
+                  <TableHead className="text-center">Qty</TableHead>
+                  {show('status') && <TableHead>Status</TableHead>}
+                  {show('scanned_at') && <TableHead>Last Scanned</TableHead>}
+                  {show('location') && <TableHead>Location</TableHead>}
+                  {show('scanned_by') && <TableHead>Scanned By</TableHead>}
+                  {show('notes') && <TableHead>Notes</TableHead>}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from(rowsByKit.entries()).map(([kitId, kitRows]) => {
+                  const kitName = kitRows[0]?.kit_name ?? '—';
+                  const isContainer = kitRows[0]?.is_container ?? false;
+                  const hasConflict = conflictFlags.has(kitId);
+                  // A container assigned directly to the gig is already a
+                  // single sealed row — a divider header above just that one
+                  // row is pure clutter, so its name/badges move onto the
+                  // row itself instead of getting a section of its own.
+                  const isStandaloneRow = isContainer && kitRows.length === 1;
+                  const columnCount = 4 + [
+                    show('status'), show('scanned_at'), show('location'), show('scanned_by'), show('notes'),
+                  ].filter(Boolean).length;
+
+                  return (
+                    <Fragment key={kitId}>
+                      {!isStandaloneRow && (
+                        <TableRow className="bg-muted/40 hover:bg-muted/40">
+                          <TableCell colSpan={columnCount} className="py-2">
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium text-sm">{kitName}</span>
+                              <KitTypeBadge isContainer={isContainer} />
+                              {hasConflict && <ConflictBadge />}
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )}
                       {kitRows.map((row, i) => {
                         const rowKey = `${row.kit_id}-${row.asset_id ?? 'kit'}-${i}`;
                         const isChecked = checkedRows.has(rowKey);
@@ -567,9 +583,18 @@ function PackingListTab({
                             />
                           </TableCell>
                           <TableCell className={`font-medium ${isChecked ? 'line-through text-muted-foreground' : ''}`}>
-                            {row.asset_name ?? row.kit_name ?? '—'}
+                            <div className="flex items-center gap-2">
+                              {row.asset_name ?? row.kit_name ?? '—'}
+                              {isStandaloneRow && (
+                                <>
+                                  <KitTypeBadge isContainer={isContainer} />
+                                  {hasConflict && <ConflictBadge />}
+                                </>
+                              )}
+                            </div>
                           </TableCell>
                           <TableCell>{row.tag_number ?? '—'}</TableCell>
+                          <TableCell className="text-center">{row.quantity}</TableCell>
                           {show('status') && (
                             <TableCell>
                               {row.status ? (
@@ -602,11 +627,11 @@ function PackingListTab({
                         </TableRow>
                         );
                       })}
-                    </TableBody>
-                  </Table>
-                </div>
-              );
-            })
+                    </Fragment>
+                  );
+                })}
+              </TableBody>
+            </Table>
           )}
         </div>
       )}

--- a/src/services/inventoryManagement.service.test.ts
+++ b/src/services/inventoryManagement.service.test.ts
@@ -599,6 +599,76 @@ describe('inventoryManagement.service', () => {
       expect(result.map((r) => r.asset_name).sort()).toEqual(['DI Box', 'SM58']);
     });
 
+    // Issue #40: quantity was read from kit_components but dropped before
+    // reaching the report row, so a "3x XLR cable" component rendered
+    // indistinguishably from a single one.
+    it('carries a component quantity greater than one through to the row', async () => {
+      const { getPackingListReport } = await import('./inventoryManagement.service');
+
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'gig_kit_assignments') {
+          return makeQueryChain({
+            data: [
+              { kit_id: 'kit-1', kit: { id: 'kit-1', name: 'Full Rack', is_container: false, tag_number: null, organization_id: 'org-1' } },
+            ],
+            error: null,
+          });
+        }
+        if (table === 'kits') {
+          return makeQueryChain({
+            data: [{ id: 'kit-1', name: 'Full Rack', category: null, is_container: false, tag_number: null }],
+            error: null,
+          });
+        }
+        if (table === 'kit_components') {
+          return makeQueryChain({
+            data: [
+              { kit_id: 'kit-1', asset_id: 'asset-xlr', child_kit_id: null, quantity: 3, asset: { id: 'asset-xlr', manufacturer_model: 'XLR Cable', tag_number: null } },
+            ],
+            error: null,
+          });
+        }
+        if (table === 'inventory_tracking') {
+          return makeQueryChain({ data: [], error: null });
+        }
+        if (table === 'gig_participants') {
+          return makeQueryChain({ data: [], error: null });
+        }
+        return makeQueryChain({ data: [], error: null });
+      });
+
+      const result = await getPackingListReport('org-1', 'gig-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ asset_name: 'XLR Cable', quantity: 3 });
+    });
+
+    // A top-level container assigned directly to the gig has no
+    // kit_components row of its own (gig_kit_assignments has no quantity
+    // column) — it's assigned once, so its row quantity is always 1.
+    it('gives a directly-assigned container row a quantity of 1', async () => {
+      const { getPackingListReport } = await import('./inventoryManagement.service');
+
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'gig_kit_assignments') {
+          return makeQueryChain({
+            data: [
+              { kit_id: 'kit-2', kit: { id: 'kit-2', name: 'Road Case', is_container: true, tag_number: 'RC-1', organization_id: 'org-1' } },
+            ],
+            error: null,
+          });
+        }
+        return makeQueryChain({ data: [], error: null });
+      });
+
+      const result = await getPackingListReport('org-1', 'gig-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ kit_id: 'kit-2', is_container: true, quantity: 1 });
+    });
+
     // The actual bug reported live: a container nested inside a
     // non-container top-level kit was exploded into its individual assets
     // instead of showing as one row for the sealed unit.

--- a/src/services/inventoryManagement.service.ts
+++ b/src/services/inventoryManagement.service.ts
@@ -88,6 +88,7 @@ export interface PackingListRow {
   asset_id?: string | null;
   asset_name?: string | null;
   tag_number?: string | null;
+  quantity: number;
   status?: string | null;
   location?: string | null;
   scanned_at?: string | null;
@@ -596,6 +597,10 @@ export async function getPackingListReport(organizationId: string, gigId: string
           asset_id: null,
           asset_name: null,
           tag_number: kit.tag_number ?? null,
+          // A top-level kit is assigned to a gig once (gig_kit_assignments
+          // has no quantity of its own) — quantity only varies for a
+          // component *inside* a kit's tree, handled below.
+          quantity: 1,
           status: kitRecord?.status ?? null,
           location: kitRecord?.location ?? null,
           scanned_at: kitRecord?.scanned_at ?? null,
@@ -614,6 +619,7 @@ export async function getPackingListReport(organizationId: string, gigId: string
             asset_id: unit.asset_id,
             asset_name: unit.asset_name,
             tag_number: unit.tag_number,
+            quantity: unit.quantity,
             status: unitRecord?.status ?? null,
             location: unitRecord?.location ?? null,
             scanned_at: unitRecord?.scanned_at ?? null,

--- a/src/services/kit.service.test.ts
+++ b/src/services/kit.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getKits, getKit, getDistinctKitValues, deleteKit, createKit, updateKit, duplicateKit, countInventoryItems, maxTreeDepth, getKitsThatWouldCycle, getKitComponentTree, KitComponentTreeNode } from './kit.service';
+import { getKits, getKit, getDistinctKitValues, deleteKit, createKit, updateKit, duplicateKit, countInventoryItems, maxTreeDepth, getKitsThatWouldCycle, getKitComponentTree, flattenToScanUnits, KitComponentTreeNode } from './kit.service';
 import { createClient } from '../utils/supabase/client';
 import { requireAuth } from '../utils/supabase/auth-utils';
 
@@ -509,5 +509,51 @@ describe('countInventoryItems / maxTreeDepth', () => {
   it('multiplies a non-container sub-kit\'s own contents by its quantity', () => {
     const nested = [kit('Duo Pack', false, 2, [asset(3)])];
     expect(countInventoryItems(nested)).toBe(6);
+  });
+});
+
+describe('flattenToScanUnits', () => {
+  const owningKit = { id: 'kit-top', name: 'Full Rack' };
+
+  const asset = (quantity: number, id = 'asset-1', model = 'DI Box'): KitComponentTreeNode => ({
+    clientKey: `asset-${id}`,
+    type: 'asset',
+    quantity,
+    asset: { id, manufacturer_model: model, tag_number: null },
+    children: [],
+  });
+
+  const kit = (id: string, isContainer: boolean, quantity: number, children: KitComponentTreeNode[]): KitComponentTreeNode => ({
+    clientKey: `kit-${id}`,
+    type: 'kit',
+    quantity,
+    kit: { id, name: id, category: null, is_container: isContainer, tag_number: null },
+    children,
+  });
+
+  // Issue #40: quantity used to be dropped entirely — a "3x XLR cable"
+  // component was indistinguishable from a single one in the packing list.
+  it('carries a loose asset\'s own quantity through to its scan unit', () => {
+    const units = flattenToScanUnits([asset(3, 'asset-xlr', 'XLR Cable')], owningKit);
+    expect(units).toEqual([
+      expect.objectContaining({ asset_id: 'asset-xlr', asset_name: 'XLR Cable', quantity: 3 }),
+    ]);
+  });
+
+  it('carries a container sub-kit\'s own quantity through to its scan unit', () => {
+    const units = flattenToScanUnits([kit('kit-case', true, 2, [asset(1)])], owningKit);
+    expect(units).toEqual([
+      expect.objectContaining({ kit_id: 'kit-case', is_container: true, quantity: 2 }),
+    ]);
+  });
+
+  it('attributes a transparent non-container sub-kit\'s assets to the owning kit, each with its own quantity', () => {
+    const units = flattenToScanUnits(
+      [kit('kit-lighting', false, 1, [asset(4, 'asset-par', 'LED Par')])],
+      owningKit
+    );
+    expect(units).toEqual([
+      expect.objectContaining({ kit_id: owningKit.id, asset_id: 'asset-par', quantity: 4 }),
+    ]);
   });
 });

--- a/src/services/kit.service.ts
+++ b/src/services/kit.service.ts
@@ -652,6 +652,10 @@ export interface ScanUnit {
   asset_id: string | null;
   asset_name: string | null;
   tag_number: string | null;
+  /** The component's own quantity (e.g. "3x XLR cable") — scanning tracks
+   * status per asset_id, not per physical copy, so this is a count shown
+   * alongside the row rather than a reason to emit multiple rows. */
+  quantity: number;
 }
 
 /**
@@ -676,6 +680,7 @@ export function flattenToScanUnits(nodes: KitComponentTreeNode[], owningKit: { i
         asset_id: node.asset?.id ?? null,
         asset_name: node.asset?.manufacturer_model ?? null,
         tag_number: node.asset?.tag_number ?? null,
+        quantity: node.quantity,
       });
     } else if (node.kit?.is_container) {
       units.push({
@@ -685,6 +690,7 @@ export function flattenToScanUnits(nodes: KitComponentTreeNode[], owningKit: { i
         asset_id: null,
         asset_name: null,
         tag_number: node.kit.tag_number ?? null,
+        quantity: node.quantity,
       });
     } else {
       units.push(...flattenToScanUnits(node.children, owningKit));

--- a/supabase/functions/_shared/sentry.ts
+++ b/supabase/functions/_shared/sentry.ts
@@ -29,3 +29,18 @@ export async function captureException(error: unknown): Promise<void> {
     console.error('Sentry capture failed:', sentryError);
   }
 }
+
+/**
+ * Capture a message (not a thrown error) at the given severity level, e.g. a
+ * degraded-but-running config that has no exception to throw. Same
+ * no-op-without-DSN and explicit-flush behavior as captureException.
+ */
+export async function captureMessage(message: string, level: 'warning' | 'error' = 'warning'): Promise<void> {
+  if (!dsn) return;
+  try {
+    Sentry.captureMessage(message, level);
+    await Sentry.flush(2000);
+  } catch (sentryError) {
+    console.error('Sentry capture failed:', sentryError);
+  }
+}

--- a/supabase/functions/server/lib/pure/webauthnConfig.test.ts
+++ b/supabase/functions/server/lib/pure/webauthnConfig.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { missingWebauthnConfigVars } from './webauthnConfig';
+
+describe('missingWebauthnConfigVars', () => {
+  it('returns an empty list when both vars are set', () => {
+    expect(missingWebauthnConfigVars('gigwrangler.com', 'https://gigwrangler.com')).toEqual([]);
+  });
+
+  it('names RP_ID when only it is missing', () => {
+    expect(missingWebauthnConfigVars(undefined, 'https://gigwrangler.com')).toEqual(['RP_ID']);
+  });
+
+  it('names ORIGIN when only it is missing', () => {
+    expect(missingWebauthnConfigVars('gigwrangler.com', undefined)).toEqual(['ORIGIN']);
+  });
+
+  it('names both when both are missing', () => {
+    expect(missingWebauthnConfigVars(undefined, undefined)).toEqual(['RP_ID', 'ORIGIN']);
+  });
+
+  it('treats an empty string the same as unset', () => {
+    expect(missingWebauthnConfigVars('', '')).toEqual(['RP_ID', 'ORIGIN']);
+  });
+});

--- a/supabase/functions/server/lib/pure/webauthnConfig.ts
+++ b/supabase/functions/server/lib/pure/webauthnConfig.ts
@@ -1,0 +1,17 @@
+// Pure (no Deno imports) so it is unit-testable under Vitest, same split as
+// authz.ts/cors.ts — the Deno.env reads and Sentry reporting stay in
+// webauthnConfig.ts, this just decides what's missing.
+
+/**
+ * Which of the WebAuthn relying-party env vars are absent, given their raw
+ * (pre-fallback) values. An empty string counts as absent — same as unset.
+ */
+export function missingWebauthnConfigVars(
+  rpId: string | undefined,
+  origin: string | undefined
+): string[] {
+  const missing: string[] = [];
+  if (!rpId) missing.push('RP_ID');
+  if (!origin) missing.push('ORIGIN');
+  return missing;
+}

--- a/supabase/functions/server/lib/webauthnConfig.ts
+++ b/supabase/functions/server/lib/webauthnConfig.ts
@@ -1,8 +1,33 @@
 // WebAuthn relying-party config. RP_NAME defaults to the real product name
 // (was the Figma Make scaffolding 'Field Ops Mobile'); override via env.
+import { missingWebauthnConfigVars } from './pure/webauthnConfig.ts';
+import { captureMessage } from '../../_shared/sentry.ts';
+
+const rpIdEnv = Deno.env.get('RP_ID');
+const originEnv = Deno.env.get('ORIGIN');
+
 export const RP_NAME = Deno.env.get('RP_NAME') || 'GigWrangler';
-export const RP_ID = Deno.env.get('RP_ID') || 'localhost';
-export const ORIGIN = Deno.env.get('ORIGIN') || 'http://localhost:3000';
+export const RP_ID = rpIdEnv || 'localhost';
+export const ORIGIN = originEnv || 'http://localhost:3000';
+
+const missingConfigVars = missingWebauthnConfigVars(rpIdEnv, originEnv);
+let fallbackReported = false;
+
+/**
+ * Reports (once per isolate, on first use — not at module load, so the
+ * event carries request context and a DSN-less local `functions serve`
+ * never fires it) that a passkey route is running on the localhost RP_ID/
+ * ORIGIN fallback instead of deployed config. See issue #50: this silently
+ * broke prod passkeys for an unknown period with zero signal.
+ */
+export function reportWebauthnConfigFallback(): void {
+  if (fallbackReported || missingConfigVars.length === 0) return;
+  fallbackReported = true;
+  void captureMessage(
+    `WebAuthn running on localhost fallback config — missing env var(s): ${missingConfigVars.join(', ')}`,
+    'warning'
+  );
+}
 
 export function base64urlEncode(buf: Uint8Array): string {
   return btoa(String.fromCharCode(...buf))

--- a/supabase/functions/server/routes/webauthn.ts
+++ b/supabase/functions/server/routes/webauthn.ts
@@ -3,13 +3,16 @@ import { WebAuthnServer } from '../deps.ts';
 import { requireUser } from '../lib/auth.ts';
 import { supabaseAdmin } from '../lib/supabaseAdmin.ts';
 import * as kv from '../kv_store.ts';
-import { RP_NAME, RP_ID, ORIGIN, base64urlEncode, base64urlDecode } from '../lib/webauthnConfig.ts';
+import {
+  RP_NAME, RP_ID, ORIGIN, base64urlEncode, base64urlDecode, reportWebauthnConfigFallback,
+} from '../lib/webauthnConfig.ts';
 
 // WebAuthn device enrollment + unlock. register/* require auth (enrolling the
 // caller's device); authenticate/* are public by design (Q-E — the unlock flow,
 // gating only the cosmetic mobile lock, not data access).
 export function registerWebauthn(app: App) {
   app.post('/webauthn/register/options', requireUser, async (c) => {
+    reportWebauthnConfigFallback();
     const user = c.get('user');
 
     const { data: devices } = await supabaseAdmin
@@ -30,6 +33,7 @@ export function registerWebauthn(app: App) {
   });
 
   app.post('/webauthn/register/verify', requireUser, async (c) => {
+    reportWebauthnConfigFallback();
     const user = c.get('user');
     const { registrationResponse, deviceName } = await c.req.json();
 
@@ -79,6 +83,7 @@ export function registerWebauthn(app: App) {
 
   // Public (Q-E): unlock flow identifies the user by email.
   app.post('/webauthn/authenticate/options', async (c) => {
+    reportWebauthnConfigFallback();
     const { email } = await c.req.json();
     if (!email) {
       return c.json({ error: 'Email is required' }, 400);
@@ -108,6 +113,7 @@ export function registerWebauthn(app: App) {
 
   // Public (Q-E).
   app.post('/webauthn/authenticate/verify', async (c) => {
+    reportWebauthnConfigFallback();
     const { authenticationResponse, email } = await c.req.json();
     if (!email || !authenticationResponse) {
       return c.json({ error: 'Email and response are required' }, 400);


### PR DESCRIPTION
## Summary

Two independent, fully-scoped fixes picked up from today's triage pass (see #41).

**#50 — WebAuthn silently falls back to localhost defaults when RP_ID/ORIGIN are unset**
- Added `captureMessage(message, level)` to `_shared/sentry.ts`, mirroring the existing `captureException` (no-op without `SENTRY_DSN`, explicit `flush()` before isolate teardown).
- `webauthnConfig.ts` now computes which of `RP_ID`/`ORIGIN` are missing via a small pure helper, and exposes `reportWebauthnConfigFallback()` — fired lazily on first hit of each of the 4 passkey routes (not at module load), so local `functions serve` stays silent and the event carries request context.
- Reports unconditionally rather than gating on `SENTRY_ENVIRONMENT` — the no-DSN no-op is what actually keeps dev quiet.

**#40 — Packing list improvements**
- `PackingListTab` now renders one `<Table>`/one header for the whole gig instead of a separate table per kit.
- A kit group collapses to a divider row spanning all visible columns; a container assigned directly to the gig (already just one row) skips the divider entirely and gets its name/badges inline instead.
- Added a Qty column. `kit_components.quantity` was already read from the DB (via `getKitComponentTree`) but dropped before reaching `ScanUnit` (`kit.service.ts`) / `PackingListRow` (`inventoryManagement.service.ts`) — threaded it through both.

## Test plan
- [x] `npm run test:run` — 851/851 passing, including new tests:
  - `supabase/functions/server/lib/pure/webauthnConfig.test.ts` (missing-var detection)
  - `kit.service.test.ts` — `flattenToScanUnits` carries quantity through for assets, containers, and transparent non-container sub-kits
  - `inventoryManagement.service.test.ts` — `getPackingListReport` quantity propagation (component qty > 1, and directly-assigned container qty = 1)
  - `InventoryReports.test.tsx` (new file) — single `<table>` for a multi-kit packing list, Qty column renders, divider row present for a multi-item kit group and absent for a standalone container row
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `npm run typecheck` — clean
- [ ] Manual verification against a real deployed passkey flow and a real gig's packing list is still worth doing before merge — I don't have a way to exercise either against live Supabase/Sentry from this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYuGFPLcZ2n92fW6Ytc5Xq

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYuGFPLcZ2n92fW6Ytc5Xq)_