### PR TITLE
Show a friendly message when business search fails

### DIFF
--- a/src/components/OrganizationScreen.test.tsx
+++ b/src/components/OrganizationScreen.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OrganizationScreen from './OrganizationScreen';
+
+vi.mock('../utils/supabase/client', () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      getSession: vi.fn().mockResolvedValue({ data: { session: { access_token: 'token' } } }),
+    },
+    functions: {
+      invoke: vi.fn().mockRejectedValue(new Error('Google Places API error: 400')),
+    },
+    rpc: vi.fn().mockResolvedValue({ data: null }),
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    })),
+  })),
+}));
+
+const mockProps = {
+  onOrganizationCreated: vi.fn(),
+  onCancel: vi.fn(),
+  userId: 'user-1',
+};
+
+describe('OrganizationScreen — business search failure', () => {
+  // Issue #29: a failed Google Places search used to surface the raw
+  // "Google Places API error: 400" string to the user via a toast, and fell
+  // into the same UI branch as "no results found". It must now render a
+  // distinct, friendly error state with the manual-entry fallback front and
+  // center.
+  it('shows a friendly message and manual-entry fallback instead of the raw API error', async () => {
+    const user = userEvent.setup();
+    render(<OrganizationScreen {...mockProps} />);
+
+    await user.type(screen.getByPlaceholderText('Search for your business name...'), 'Acme Co');
+    await user.click(screen.getByRole('button', { name: 'Search' }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't reach business search")).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Fill in manually instead' })).toBeInTheDocument();
+
+    expect(screen.queryByText(/Google Places API error/)).not.toBeInTheDocument();
+    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/OrganizationScreen.tsx
+++ b/src/components/OrganizationScreen.tsx
@@ -8,7 +8,7 @@
  * - App.tsx (routes: 'create-org', 'edit-org')
  */
 import { useState, useRef, useEffect } from 'react';
-import { Building2, Search, Loader2, MapPin, Phone, Globe, Check, AlertCircle, X, ChevronLeft } from 'lucide-react';
+import { Building2, Search, Loader2, MapPin, Phone, Globe, Check, AlertCircle, AlertTriangle, X, ChevronLeft } from 'lucide-react';
 import { toast } from 'sonner';
 import { 
   Organization, 
@@ -101,6 +101,8 @@ export default function OrganizationScreen({
   const [isSearching, setIsSearching] = useState(false);
   const [searchResults, setSearchResults] = useState<GooglePlace[]>([]);
   const [showResults, setShowResults] = useState(false);
+  /** True when the search request itself failed — must render distinctly from "no results found", since those mean very different things to the user. */
+  const [searchError, setSearchError] = useState(false);
   const [selectedPlace, setSelectedPlace] = useState<GooglePlace | null>(null);
   const [showManualEntry, setShowManualEntry] = useState(isEditMode); // Show form directly in edit mode
 
@@ -184,6 +186,7 @@ export default function OrganizationScreen({
     
     setIsSearching(true);
     setShowResults(true);
+    setSearchError(false);
 
     // Real API call
     try {
@@ -266,8 +269,8 @@ export default function OrganizationScreen({
       setIsSearching(false);
     } catch (error: any) {
       console.error('Error searching places:', error);
-      toast.error(error.message || 'Failed to search places. Please try again.');
       setSearchResults([]);
+      setSearchError(true);
       setIsSearching(false);
     }
   };
@@ -352,6 +355,7 @@ export default function OrganizationScreen({
   const handleManualEntry = () => {
     setShowManualEntry(true);
     setShowResults(false);
+    setSearchError(false);
     setSearchQuery('');
     toast.info('Fill in the form manually');
   };
@@ -588,6 +592,21 @@ export default function OrganizationScreen({
                   <div className="p-8 text-center">
                     <Loader2 className="h-8 w-8 animate-spin mx-auto mb-2 text-sky-500" />
                     <p className="text-sm text-gray-600">Searching Google Places...</p>
+                  </div>
+                ) : searchError ? (
+                  <div className="p-8 text-center">
+                    <AlertTriangle className="h-8 w-8 mx-auto mb-2 text-amber-600" />
+                    <p className="text-gray-900 mb-1">Couldn't reach business search</p>
+                    <p className="text-sm text-gray-600 mb-4">
+                      Enter the details manually instead.
+                    </p>
+                    <Button
+                      onClick={handleManualEntry}
+                      variant="outline"
+                      size="sm"
+                    >
+                      Fill in manually instead
+                    </Button>
                   </div>
                 ) : searchResults.length > 0 ? (
                   <div className="divide-y divide-gray-200">


### PR DESCRIPTION
## Summary

Picked up from today's triage pass (see #41).

**#29 — Show a friendly message when business/venue search is unavailable**
- A failed Google Places search (`OrganizationScreen.tsx`'s `handleSearchPlaces`) used to surface the raw backend string `"Google Places API error: 400"` to the user via a toast, and fell into the same UI branch as "no results found" — conflating a genuinely broken search with a clean empty one.
- Added a distinct `searchError` state, set only on an actual search failure (the zero-results path is untouched and still shows "No results found").
- The error state renders as its own branch, ahead of the empty-results case: friendly copy (*"Couldn't reach business search — enter the details manually"*) plus the existing manual-entry button front and center — mirroring the error-branch pattern `PersonMatchResults` already uses for Participants search failures (`AlertTriangle` + distinct copy, never conflated with "no matches").
- Scope stayed frontend-only: `unwrapFunctionsError` already prefers the backend's `details` field over the technical `error` string, so no wire-payload change was needed for this fix.

## Test plan
- [x] `npm run test:run` — 839/839 passing, including a new `OrganizationScreen.test.tsx` covering the failure path: friendly message + manual-entry button render, and neither the raw API string nor "No results found" appear.
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in touched files)
- [x] `npm run typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KykYEHTk9tTE1KLsD2xDx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01KykYEHTk9tTE1KLsD2xDx5)_