### PR TITLE
Fix cross-org RLS leak on gig_financials

### DIFF
--- a/supabase/migrations/20260912000000_fix_gig_financials_rls.sql
+++ b/supabase/migrations/20260912000000_fix_gig_financials_rls.sql
@@ -1,0 +1,37 @@
+-- Fix confirmed cross-org RLS leak on gig_financials (issue #61).
+--
+-- gig_financials carried six permissive policies: two gig-scoped ("Admins and
+-- Managers can manage gig bids" / "...can view bids for accessible gigs") via
+-- user_can_manage_gig(gig_id, ...), which is satisfied by an Admin/Manager of
+-- ANY participating org, not just the row's own organization_id. Because
+-- Postgres ORs all permissive policies together, the four org-scoped policies
+-- ("Admins can {view,insert,update,delete} their organization's financials")
+-- were fully shadowed on every command. Net effect: any Admin/Manager of any
+-- org sharing a gig could read/write every other org's financial rows on it.
+--
+-- This migration reconciles all six down to the two-policy shape already used
+-- correctly on assets/kits (single SELECT, single ALL, both scoped only to
+-- organization_id, no gig-participation fallback), matching the documented
+-- target in docs/technical/security-scheme.md §3 ("gig_financials: only
+-- accessible to Admin and Manager roles of the owning organization"). Manager
+-- is included alongside Admin per §2's role table (Manager has full CRUD on
+-- Financials) — the old org-scoped policies only checked user_is_admin_of_org,
+-- which under-scoped Manager independently of the gig-scoped leak.
+--
+-- No schema change: gig_financials.organization_id is already NOT NULL.
+
+DROP POLICY IF EXISTS "Admins and Managers can manage gig bids" ON "public"."gig_financials";
+DROP POLICY IF EXISTS "Admins and Managers can view bids for accessible gigs" ON "public"."gig_financials";
+DROP POLICY IF EXISTS "Admins can delete their organization's financials" ON "public"."gig_financials";
+DROP POLICY IF EXISTS "Admins can insert their organization's financials" ON "public"."gig_financials";
+DROP POLICY IF EXISTS "Admins can update their organization's financials" ON "public"."gig_financials";
+DROP POLICY IF EXISTS "Admins can view their organization's financials" ON "public"."gig_financials";
+
+CREATE POLICY "Admins and managers can view their organization's financials" ON "public"."gig_financials"
+  FOR SELECT
+  USING ("public"."user_is_admin_or_manager_of_org"("organization_id", "auth"."uid"()));
+
+CREATE POLICY "Admins and managers can manage their organization's financials" ON "public"."gig_financials"
+  FOR ALL
+  USING ("public"."user_is_admin_or_manager_of_org"("organization_id", "auth"."uid"()))
+  WITH CHECK ("public"."user_is_admin_or_manager_of_org"("organization_id", "auth"."uid"()));


### PR DESCRIPTION
## Summary

Fixes the headline leak from #61, pulled forward on its own per Cameron's go-ahead (the other four confirmed leaks — staffing, kit assignments, `inventory_tracking`, `activity_log` — stay deferred pending the tenant-isolation-architecture decision, as the issue recommends).

**The bug**: `gig_financials` carried six permissive RLS policies. Two were gig-scoped (`user_can_manage_gig(gig_id, ...)`, satisfied by an Admin/Manager of *any* org participating in the gig) and four were org-scoped (`user_is_admin_of_org(organization_id, ...)`, correctly narrow). Because Postgres ORs all permissive policies together, the narrow policies were fully shadowed — any Admin/Manager of any org sharing a gig could read/write every other org's financial rows on it.

**The fix**: reconciled all six down to the same two-policy shape already used correctly on `assets`/`kits`/`kit_components` (see `20260826000000_hierarchical_kits.sql` for precedent) — a single `SELECT` and a single `ALL` policy, both scoped only to `gig_financials.organization_id`, no gig-participation fallback. No schema change (`organization_id` is already `NOT NULL`).

**Scoping call, flagged for review**: I used `user_is_admin_or_manager_of_org` (Admin **and** Manager) rather than Admin-only. `security-scheme.md` §3 says Financials access is "Admin and Manager roles of the owning organization," and §2's role table lists Manager for full Financials CRUD — but the old org-scoped policies only checked `user_is_admin_of_org`, under-scoping Manager independently of the gig-scoped leak. If Admin-only was actually intended, this is a one-line change before merge.

## Verified no feature depends on the old cross-org visibility

Every real call site of `getGigFinancials()` (`useGigFinancialsData`, `MobileGigFinancials`, `GigDetailView`, `ReviewScannedDataDialog`, `GigAccountingRowDetail`) already scopes by the caller's own `organization_id`. The leak had no legitimate consumer in this codebase.

## Before / after access matrix

Gig `G` has two participant orgs: **A** (owns financial row `F`, i.e. `F.organization_id = A`) and **B** (participates in `G` but doesn't own `F`).

| Role @ Org | SELECT before | SELECT after | INSERT/UPDATE/DELETE before | INSERT/UPDATE/DELETE after |
|---|---|---|---|---|
| Admin @ A | ✅ | ✅ | ✅ | ✅ |
| Manager @ A | ✅ (only via the gig-scoped leak — the narrow policy excluded Manager) | ✅ (now via the correct policy) | ✅ (leak only) | ✅ (correct policy) |
| Staff @ A | ❌ | ❌ | ❌ | ❌ |
| Viewer @ A | ❌ | ❌ | ❌ | ❌ |
| **Admin @ B** | **✅ — the leak** | **❌ — fixed** | **✅ — the leak** | **❌ — fixed** |
| **Manager @ B** | **✅ — the leak** | **❌ — fixed** | **✅ — the leak** | **❌ — fixed** |
| Staff @ B | ❌ | ❌ | ❌ | ❌ |
| Viewer @ B | ❌ | ❌ | ❌ | ❌ |

Derived by hand from the exact policy/function definitions in `initial_schema.sql` (`user_can_manage_gig`, `user_is_admin_of_org`, `user_is_admin_or_manager_of_org`) — not run against a live database (see Test plan).

## Test plan
- [x] `npm run test:run` — 838/838 passing (unchanged from baseline; confirms nothing assumed the old behavior)
- [x] `npm run lint` — 0 errors (59 pre-existing warnings, none in touched files)
- [x] `npm run typecheck` — clean
- [x] **This sandbox has no Supabase CLI / local Postgres to run the migration against** — I could not execute the before/after matrix above as live queries. It's derived analytically from the exact policy and function source, but this touches live production financial-access data, so **please verify against a dev database (`supabase db reset` + the matrix above as real queries under two test users) before merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bxsTcdxA57SBiPUMy7fJq

---
_Generated by [Claude Code](https://claude.ai/code/session_019bxsTcdxA57SBiPUMy7fJq)_